### PR TITLE
Always update URL based on scroll position

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -195,19 +195,21 @@ $(function(){
 })
 
 // Hash update with scroll on ditap page
-$(function(){
-  if (location.pathname == '/services/ditap/') {
-    $(document).bind('scroll',function(e){
-      $('h2').each(function(){
-          if (
-            $(this).offset().top < window.pageYOffset + 10 &&
-            $(this).offset().top + $(this).height() > window.pageYOffset + 10
-          ) {
-             var urlId = '#' + $(this).attr('id');
-             history.replaceState(null, null, urlId);
-          }
+$(function() {
+  if (location.pathname == "/services/ditap/") {
+    const headings = $("h2");
+    window.setInterval(function() {
+      headings.each(function(i) {
+        if (
+          window.pageYOffset > $(this).offset().top &&
+          (i === headings.length - 1 ||
+            window.pageYOffset < headings.eq(i + 1).offset().top)
+        ) {
+          var urlId = "#" + $(this).attr("id");
+          history.replaceState(null, null, urlId);
+        }
       });
-    });
+    }, 100);
   }
 });
 


### PR DESCRIPTION
Currently,  if you scroll up and down really quickly on the DITAP page, it doesn't seem to fire off any event to change the URL to the appropriate section.

This change should fix that, so that the URL always reflects the current section you are in.