### PR TITLE
Prevent flooding history stack on "careers" page

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -127,11 +127,13 @@ $(function() {
         }
       });
 
-      var url = currentHeading
+      var hash = currentHeading
         ? "#" + currentHeading.id
-        : ".";
+        : "";
 
-      history.replaceState(null, "", url);
+      if (hash !== window.location.hash) {
+        history.replaceState(null, "", hash || ".");
+      }
     });
   }
 }); // Pre-populate date select on ditap application

--- a/js/script.js
+++ b/js/script.js
@@ -117,20 +117,21 @@ $(function() {
     location.pathname === "/careers/join/"
   ) {
     var headings = $("h2");
+
     window.setInterval(function() {
-      headings.each(function(i) {
-        if (
-          window.pageYOffset >= $(this).offset().top &&
-          (i === headings.length - 1 ||
-            window.pageYOffset < headings.eq(i + 1).offset().top)
-        ) {
-          var urlId = "#" + $(this).attr("id");
-          history.replaceState(null, null, urlId);
-        } else if (i === 0 && window.pageYOffset < $(this).offset().top - 1) {
-          var newUrl = window.location.pathname + window.location.search;
-          history.pushState("", document.title, newUrl);
+      var currentHeading = null;
+
+      headings.each(function(index, element) {
+        if (window.pageYOffset >= $(element).offset().top) {
+          currentHeading = element;
         }
       });
+
+      var url = currentHeading
+        ? "#" + currentHeading.id
+        : ".";
+
+      history.replaceState(null, "", url);
     }, 100);
   }
 }); // Pre-populate date select on ditap application

--- a/js/script.js
+++ b/js/script.js
@@ -118,7 +118,7 @@ $(function() {
   ) {
     var headings = $("h2");
 
-    $(window).on("scroll", function() {
+    $(window).scroll(function() {
       var currentHeading = null;
 
       headings.each(function(index, element) {

--- a/js/script.js
+++ b/js/script.js
@@ -118,7 +118,7 @@ $(function() {
   ) {
     var headings = $("h2");
 
-    window.setInterval(function() {
+    $(window).on("scroll", function() {
       var currentHeading = null;
 
       headings.each(function(index, element) {
@@ -132,7 +132,7 @@ $(function() {
         : ".";
 
       history.replaceState(null, "", url);
-    }, 100);
+    });
   }
 }); // Pre-populate date select on ditap application
 


### PR DESCRIPTION
Hey there!

I ran into a few weird issues at `/careers/join/`. The main issue was that my browser's history was being flooded with entries:

<img width="245" alt="Screen Shot 2020-07-09 at 3 10 29 PM" src="https://user-images.githubusercontent.com/2635560/87095921-8b376380-c1f6-11ea-8422-eea3f54f621e.png">

This was due to rapid calls to `history.pushState` inside of a `setInterval`. It also had the side effect of causing my mouse cursor to constantly flash between the "pointer" and "cursor" styles when viewing the page in Chrome on ChromeOS (which is how I originally noticed it).

Anyways, I think this should fix it. Thanks!