### PR TITLE
Add max-width to about page image section

### DIFF
--- a/_sass/_utilities.scss
+++ b/_sass/_utilities.scss
@@ -48,6 +48,10 @@
   color: $black;
 }
 
+.container-xxl {
+  max-width: map-get($container-max-widths, "xxl");
+}
+
 .container-xl {
   max-width: map-get($container-max-widths, "xl");
 }

--- a/_sass/_utilities.scss
+++ b/_sass/_utilities.scss
@@ -48,6 +48,10 @@
   color: $black;
 }
 
+.container-xl {
+  max-width: map-get($container-max-widths, "xl");
+}
+
 .container-lg {
   max-width: map-get($container-max-widths, "lg");
 }

--- a/_sass/bootstrap/_variables.scss
+++ b/_sass/bootstrap/_variables.scss
@@ -225,7 +225,8 @@ $container-max-widths: (
   sm: 540px,
   md: 720px,
   lg: 960px,
-  xl: 1140px
+  xl: 1140px,
+  xxl: 1320px
 ) !default;
 @include _assert-ascending($container-max-widths, "$container-max-widths");
 

--- a/pages/about.html
+++ b/pages/about.html
@@ -53,7 +53,7 @@ preload: hero-about-us.svg
   </section>
 
   {% if site.data.team[0] %}
-    <section id="meet-the-team" class="page-block">
+    <section id="meet-the-team" class="mx-auto container-xl">
       <div class="page-block-header-2">
         <h2>Meet the team</h2>
       </div>

--- a/pages/about.html
+++ b/pages/about.html
@@ -53,7 +53,7 @@ preload: hero-about-us.svg
   </section>
 
   {% if site.data.team[0] %}
-    <section id="meet-the-team" class="mx-auto container-xl">
+    <section id="meet-the-team" class="mx-auto container-xxl">
       <div class="page-block-header-2">
         <h2>Meet the team</h2>
       </div>


### PR DESCRIPTION
Avoids image proportions from being too short and photos cutting off on large screens by setting a max-width.

[😎 Preview](https://deploy-preview-131--skylight-demo.netlify.app/company/about/)