### PR TITLE
Draft: Switch font-family 

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -239,6 +239,8 @@
   <meta name="theme-color" content="#ffffff">
 
   <link rel="stylesheet" href="/css/font-awesome.min.css" type="text/css">
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}?{{site.time | date: '%s%N'}}" type="text/css">
   {% if page.preload %}
     <link rel="preload" href="/img/{{ page.preload }}" as="image">

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -136,7 +136,10 @@ $link-hover-color: darken($link-color, 15%) !default;
 $link-hover-decoration: none;
 
 // Fonts
-$font-family-sans-serif: 'Geomanist', sans-serif;
+// $font-family-sans-serif: 'Geomanist', sans-serif;
+$font-family-system: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji;
+
+$font-family-sans-serif: 'Libre Franklin', $font-family-system;
 
 $font-size-base: $font-size-medium;
 $font-size-lg: $font-size-large;
@@ -153,10 +156,10 @@ $font-size-h4: $font-size-small;
 $font-size-h5: 1.25rem;
 
 $font-weight-normal: 400;
-$font-weight-bold: 700;
+$font-weight-bold: 600;
 
 $headings-margin-bottom: 0;
-$headings-font-weight: 700;
+$headings-font-weight: 600;
 
 $lead-font-weight: 100;
 


### PR DESCRIPTION
I switched the font-family to Libre Franklin from Geohumanist so you can review what it looks like with the updated brand typeface. I pulled screenshots of a few pages below. I think it looks okay?

![screencapture-127-0-0-1-4000-2021-02-23-17_31_49](https://user-images.githubusercontent.com/471514/108918111-d4f68200-75fe-11eb-843d-ba42b8160c0f.png)

![screencapture-127-0-0-1-4000-work-services-2021-02-23-17_40_07](https://user-images.githubusercontent.com/471514/108918142-e3449e00-75fe-11eb-806f-d9451ced5549.png)

![screencapture-127-0-0-1-4000-work-toolkits-2021-02-23-17_39_55](https://user-images.githubusercontent.com/471514/108918123-dc1d9000-75fe-11eb-9926-746790cf578c.png)




 