### PR TITLE
Fix Mobile Styling For Contracting & Press Pages

### DIFF
--- a/_sass/pages/_common.scss
+++ b/_sass/pages/_common.scss
@@ -226,3 +226,12 @@
   @extend %btn-page;
   min-width: 200px;
 }
+
+// prevent container width overflow due to container-md
+@include media-breakpoint-down(xs) {
+  .container-md {
+    width: 100%;
+    padding-left: 15px;
+    padding-right: 15px;
+  }
+}


### PR DESCRIPTION
@cscairns - I think this is for you to review, let me know if I should @ someone else.

Submitting a PR to touch up some mobile styling on your website. I happened to be on my phone when I was looking through your website and noticed the page content is overflowing your layout [here](https://skylight.digital/connect/contracting/) and [here](https://skylight.digital/company/press/) below ~`635px`. 

The offending entity appears to be `.container-md` which you're using to enforce white space on the layout at larger sizes. The `max-width` calculation is returning `720px` which is causing the overflow. A basic solution I put together is to add a Bootstrap media-query helper to tell the container to behave below the `xs` breakpoint. This prevents the overflow while maintaining your larger layouts (see images; left is local fixed and right is current prod).

As an outsider if this doesn't match your house coding style, feel free to let me know improvements or modifications and I will make further changes.

![Screen Shot 2021-03-29 at 5 28 55 PM](https://user-images.githubusercontent.com/25416999/112903242-3ce43080-90b5-11eb-898c-8b541a00be3f.png)

![Screen Shot 2021-03-29 at 5 28 35 PM](https://user-images.githubusercontent.com/25416999/112903305-4ff70080-90b5-11eb-8b27-1728c7f78136.png)
