### PR TITLE
Add hash to page history when clicking on persons links on about page

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -397,5 +397,9 @@ $(function() {
 
       setTimeout( scroll, 300 );
     }
+    $(".employee-footer a").click(function(){
+      var parentID = $(this).closest( ".employee-col" ).attr('id');
+      window.location.hash = parentID;
+    })
   }
 })


### PR DESCRIPTION
When you click on someones link on the about page, their name hash id is added to the url, so when you click the back button, that person is brought into view on the page after the page randomizes