### PR TITLE
Fix hamburger color on Brand page

### DIFF
--- a/_sass/pages/_brand.scss
+++ b/_sass/pages/_brand.scss
@@ -230,7 +230,17 @@
   .burger span,
   .burger span:before,
   .burger span:after {
-    background: white;
+    background: white !important;
+  }
+
+  .navbar-toggler[aria-expanded="true"] {
+    .burger {
+      &:hover {
+        span {
+          background-color: transparent !important;
+        }
+      }
+    }
   }
 
   @include media-breakpoint-down(lg) {


### PR DESCRIPTION
This should fix the issue with https://skylight.digital/brand/ on mobile where the hamburger menu icon turns black when clicked.