### PR TITLE
add padding to mobile version of the application

### DIFF
--- a/css/greenhouse.css
+++ b/css/greenhouse.css
@@ -171,11 +171,18 @@ h3#filter-count {
 }
 
 /* Job Post Page */
+
 div#main div#app_body {
-  padding-left: 0 !important;
-  padding-right: 0;
   background-color: var(--full-page-background-color);
 }
+
+@media (max-width: 640px) {
+  div#main:has(> div#app_body)  {
+    padding-left: 10px;
+    padding-right: 10px;
+  }   
+}
+
 
 div#app_body #header {
   display: flex;
@@ -232,7 +239,6 @@ div#submit_buttons input#submit_app {
 
 div#app_body {
   max-width: none;
-  padding-right: 20px;
 }
 
 div#application hr:nth-last-of-type(1) {


### PR DESCRIPTION
realized the Greenhouse job application on mobile viewports was missing padding, so I added it.

Before: 
<img width="833" alt="Screenshot 2023-03-14 at 10 41 08 AM" src="https://user-images.githubusercontent.com/29645040/225036772-1e1ac897-7921-4f79-a4dc-f417390c5126.png">

After:
<img width="847" alt="Screenshot 2023-03-14 at 10 41 21 AM" src="https://user-images.githubusercontent.com/29645040/225036850-03159d74-e024-4638-bd25-75f139c8c6fe.png">
