### PR TITLE
Ordered open positions to not throw off anchor links

### DIFF
--- a/pages/join.html
+++ b/pages/join.html
@@ -19,24 +19,19 @@ works." color = "green" image = "hero-join-us.svg" %}
         <nav class="subnav-col px-0" id="sidenav">
           <ul>
             <li class="current">
-              <a class="nav-link" href="#why-skylight" aria-current="location"
-                >Why Skylight?</a
-              >
+              <a class="nav-link" href="#why-skylight" aria-current="location">Why Skylight?</a>
             </li>
             <li><a class="nav-link" href="#care-package">Care package</a></li>
             <li>
-              <a class="nav-link" href="#open-positions">Open positions</a>
+              <a class="nav-link" href="#interview-process">Interview process</a>
             </li>
             <li>
-              <a class="nav-link" href="#interview-process"
-                >Interview process</a
-              >
+              <a class="nav-link" href="#open-positions">Open positions</a>
             </li>
           </ul>
         </nav>
       </div>
     </div>
-
     <section class="col-12 col-md-9 page--join__text">
       <div class="text" id="join">
         <h2 class="mt-0" id="why-skylight">Why Skylight?</h2>
@@ -52,29 +47,22 @@ works." color = "green" image = "hero-join-us.svg" %}
           <a href="/company/about/">team</a> — is designed with that purpose in
           mind.
         </p>
-
         <h3>You matter</h3>
         <p>
           It’s people like you — with talents in research, design, product,
           engineering, data, and more — who can make a difference. We’ve created
           an environment that empowers you to unleash your skills for public
           good, whether that’s improving
-          <a href="/work/experience/ct-ece-reporter/"
-            >early childhood outcomes</a
-          >
+          <a href="/work/experience/ct-ece-reporter/">early childhood outcomes</a>
           or
-          <a href="/work/experience/va-diffusion-marketplace/"
-            >helping to save veteran lives</a
-          >. You’ll work alongside a team of
-          <a href="/company/about/#meet-the-team"
-            >extraordinarily-talented people</a
-          >
+          <a href="/work/experience/va-diffusion-marketplace/">helping to save veteran lives</a>. You’ll work alongside
+          a team of
+          <a href="/company/about/#meet-the-team">extraordinarily-talented people</a>
           who strive to bring out the best in you and each other. You’ll also be
           taken care of with a well-thought-out
           <a href="#care-package">compensation and benefits package</a>. We want
           you to be happy, fulfilled, and well-supported.
         </p>
-
         <h3>We’re just getting started</h3>
         <p>
           We’re still in startup mode, and our future is bright. We’re doing
@@ -82,21 +70,17 @@ works." color = "green" image = "hero-join-us.svg" %}
           Everyone is given the opportunity to shape the company in some way.
           We’d love for you to join us in creating something special.
         </p>
-
         <div class="image-list row">
           <div class="col-sm-4 col-lg-3">
             <div class="employee-gradient employee-gradient__img">
-              <img
-                class="image-list__employee-img"
-                src="{{ site.baseurl }}/img/people/tiffany-nieh.jpg"
-                alt="Tiffany Nieh"
-              />
+              <img class="image-list__employee-img" src="{{ site.baseurl }}/img/people/tiffany-nieh.jpg"
+                alt="Tiffany Nieh" />
             </div>
           </div>
           <div class="join__quote col-sm-8 col-lg-9">
             <p class="quote-text font-size-large">
-              “The work we do at Skylight is meaningful, 
-              and I value the autonomy that Skylight provides, 
+              “The work we do at Skylight is meaningful,
+              and I value the autonomy that Skylight provides,
               which allows space for me to create products that both clients and users love.”
             </p>
             <p class="join-quote__byline">
@@ -104,15 +88,11 @@ works." color = "green" image = "hero-join-us.svg" %}
             </p>
           </div>
         </div>
-
         <div class="image-list row">
           <div class="col-sm-4 col-lg-3">
             <div class="employee-gradient employee-gradient__img">
-              <img
-                class="image-list__employee-img"
-                src="{{ site.baseurl }}/img/people/karthik-patil.jpg"
-                alt="Karthik Patil"
-              />
+              <img class="image-list__employee-img" src="{{ site.baseurl }}/img/people/karthik-patil.jpg"
+                alt="Karthik Patil" />
             </div>
           </div>
           <div class="join__quote col-sm-8 col-lg-9">
@@ -121,21 +101,16 @@ works." color = "green" image = "hero-join-us.svg" %}
               achieve digital mastery, which is what the government needs more
               of from industry.”
             </p>
-
             <p class="join-quote__byline">
               – <b>Karthik Patil,</b> VP of Defense Services
             </p>
           </div>
         </div>
-
         <div class="image-list row">
           <div class="col-sm-4 col-lg-3">
             <div class="employee-gradient employee-gradient__img">
-              <img
-                class="image-list__employee-img"
-                src="{{ site.baseurl }}/img/people/laura-king.jpg"
-                alt="Laura King"
-              />
+              <img class="image-list__employee-img" src="{{ site.baseurl }}/img/people/laura-king.jpg"
+                alt="Laura King" />
             </div>
           </div>
           <div class="join__quote col-sm-8 col-lg-9">
@@ -143,20 +118,17 @@ works." color = "green" image = "hero-join-us.svg" %}
               “Skylight gives me ownership over my work and allows me to carve a
               path where I can make the biggest impact.”
             </p>
-
             <p class="join-quote__byline">
               – <b>Laura King,</b> Service Designer
             </p>
           </div>
         </div>
-
         <h2 id="care-package">Care package</h2>
         <p class="text-intro">
           We hire good people and support them with the best compensation and
           benefits possible. We keep an open dialog with everyone on the team to
           make what we offer even better.
         </p>
-
         <div class="text-grid row section__care-package">
           <div class="col-12 col-lg-4">
             {% include icons/join/compensation.svg %}
@@ -167,7 +139,6 @@ works." color = "green" image = "hero-join-us.svg" %}
               referral bonuses, and a quick-pay program.
             </p>
           </div>
-
           <div class="col-12 col-lg-4">
             {% include icons/join/future.svg %}
             <h3>Future</h3>
@@ -178,7 +149,6 @@ works." color = "green" image = "hero-join-us.svg" %}
               materials.
             </p>
           </div>
-
           <div class="col-12 col-lg-4">
             {% include icons/join/health.svg %}
             <h3>Health</h3>
@@ -190,16 +160,14 @@ works." color = "green" image = "hero-join-us.svg" %}
               health savings account.
             </p>
           </div>
-
           <div class="col-12 col-lg-4">
             {% include icons/join/parental-leave.svg %}
             <h3>Parental leave</h3>
             <p>
-              We offer up to 12 weeks paid time off for all eligible 
-              new birth, adoption, or foster parents. 
+              We offer up to 12 weeks paid time off for all eligible
+              new birth, adoption, or foster parents.
             </p>
           </div>
-
           <div class="col-12 col-lg-4">
             {% include icons/join/time-off.svg %}
             <h3>Time off</h3>
@@ -208,7 +176,6 @@ works." color = "green" image = "hero-join-us.svg" %}
               holidays. We also offer a flexible sick leave policy.
             </p>
           </div>
-
           <div class="col-12 col-lg-4">
             {% include icons/join/flexibility.svg %}
             <h3>Flexibility</h3>
@@ -218,7 +185,6 @@ works." color = "green" image = "hero-join-us.svg" %}
               currently spread out across {{site.state_count}} different states.
             </p>
           </div>
-
           <div class="col-12 col-lg-4">
             {% include icons/join/shopping-cart.svg %}
             <h3>Stuff</h3>
@@ -250,206 +216,215 @@ works." color = "green" image = "hero-join-us.svg" %}
               We give you multiple pathways to engage with your community. We
               match 100% of any charitable donations you make, up to $500 per
               year, and offer access to community networks, such as the
-              <a href="https://digitalservicescoalition.org/"
-                >Digital Services Coalition</a
-              >, which we co-founded.
+              <a href="https://digitalservicescoalition.org/">Digital Services Coalition</a>, which we co-founded.
             </p>
           </div>
         </div>
       </div>
-  
-      {% include open_positions.html%}
 
-    <div id="interviewing">
 
-      <div class="callout--tip left-justified-list">
-        <p class="callout_title">Is an internship or apprenticeship right for me?</p>
-        <ul class="">
-          <li>
-            An internship is short term, generally lasting 2–3 months. An apprenticeship may last for 12 months or more. 
-            If you do an internship, there may be an option at the end to extend to an apprenticeship.
-          </li>
-          <li>
-            Whether you apply for an internship or apprenticeship, 
-            our goal is to help you build professional experience, mentor you, and give you exposure to real client projects. 
-            Both types of roles are paid and can lead to a full-time role if you’re a good fit for Skylight. 
-          </li>
-        </ul>
-      </div>
-      
+
       <div id="interviewing">
-        <h2 id="interview-process">Interview process</h2>
-        <p class="text-intro">
-          If you apply for a position, here’s what you can expect in terms of
-          the process:
-        </p>
 
-        <div class="interview-explanation left-justified-list text">
-          <h3>Interview basics</h3>
-          <p>
-            We strongly prioritize the human element of the workplace, so the
-            goal of our interview process is to get to know you and how you
-            work. We don’t look for perfection; we look for a growth mindset,
-            excellent communication skills, ability to deal with ambiguity, and
-            capability to adapt. You won’t be penalized for taking time to think
-            before responding, asking to repeat a question, or correcting
-            yourself. With that in mind, please note:
-          </p>
-
-          <ul>
+        <div class="callout--tip left-justified-list">
+          <p class="callout_title">Is an internship or apprenticeship right for me?</p>
+          <ul class="">
             <li>
-              All of our screenings and interviews occur via videoconference.
+              An internship is short term, generally lasting 2–3 months. An apprenticeship may last for 12 months or
+              more.
+              If you do an internship, there may be an option at the end to extend to an apprenticeship.
             </li>
             <li>
-              A Google Meet or Zoom link will be included in your calendar
-              invitation.
-            </li>
-            <li>
-              Dress in a way that makes you comfortable. No need for blazers or
-              button ups if you prefer a hoodie.
-            </li>
-            <li>
-              We're an equal opportunity employer. If you need reasonable
-              accommodations for a disability, please <a href="mailto:recruiting@skylight.digital">reach out to us</a> 
-              with your accommodation request.
+              Whether you apply for an internship or apprenticeship,
+              our goal is to help you build professional experience, mentor you, and give you exposure to real client
+              projects.
+              Both types of roles are paid and can lead to a full-time role if you’re a good fit for Skylight.
             </li>
           </ul>
-          We use the interview process to not only evaluate whether you’re a
-          good fit for Skylight, but also to map you to a
-          <a  href="/careers/career-pathways/">career level</a>, which ultimately
-          determines your salary range.
         </div>
+
+        <div id="interviewing">
+          <h2 id="interview-process">Interview process</h2>
+          <p class="text-intro">
+            If you apply for a position, here’s what you can expect in terms of
+            the process:
+          </p>
+
+          <div class="interview-explanation left-justified-list text">
+            <h3>Interview basics</h3>
+            <p>
+              We strongly prioritize the human element of the workplace, so the
+              goal of our interview process is to get to know you and how you
+              work. We don’t look for perfection; we look for a growth mindset,
+              excellent communication skills, ability to deal with ambiguity, and
+              capability to adapt. You won’t be penalized for taking time to think
+              before responding, asking to repeat a question, or correcting
+              yourself. With that in mind, please note:
+            </p>
+
+            <ul>
+              <li>
+                All of our screenings and interviews occur via videoconference.
+              </li>
+              <li>
+                A Google Meet or Zoom link will be included in your calendar
+                invitation.
+              </li>
+              <li>
+                Dress in a way that makes you comfortable. No need for blazers or
+                button ups if you prefer a hoodie.
+              </li>
+              <li>
+                We're an equal opportunity employer. If you need reasonable
+                accommodations for a disability, please <a href="mailto:recruiting@skylight.digital">reach out to us</a>
+                with your accommodation request.
+              </li>
+            </ul>
+            We use the interview process to not only evaluate whether you’re a
+            good fit for Skylight, but also to map you to a
+            <a href="/careers/career-pathways/">career level</a>, which ultimately
+            determines your salary range.
+          </div>
+
+          <div class="interview-explanation">
+            <h3>Interview steps</h3>
+
+            <p>
+              After you submit your application, we’ll evaluate your information
+              against the qualifications of our open positions. If you look like a
+              potential match, we’ll begin the interview process and communicate
+              the next steps.
+            </p>
+
+            <h4>1. Preliminary screening</h4>
+            <p>
+              The interview process begins with a 15-minute preliminary screening.
+              We’ll send you an email beforehand with background information about
+              Skylight. Plan to talk about your skills and experience and what
+              you’re passionate about. The call will also cover the interview
+              process and basic employment requirements.
+            </p>
+            <p>
+              Hiring managers will review notes from the screening, your resume,
+              and portfolio (if applicable). If it’s a good fit, we’ll schedule
+              you for a skills interview.
+            </p>
+
+            <h4>2. Skills interview</h4>
+            <p>
+              The skills interview runs between 60 and 90 minutes. You’ll meet
+              with two interviewers with experience in your discipline. They’ll
+              ask a variety of questions about your experience and skills, and how
+              you’d apply them within the context of Skylight’s work. We’ll leave
+              you with 10–15 minutes at the end for your questions.
+            </p>
+          </div>
+        </div>
+
+        <div class="callout--tip left-justified-list">
+          <p class="callout_title">What to expect, by role:</p>
+          <ul class="">
+            <li>
+              <p class="callout_subtitle">Product manager</p>
+              Meeting with other product experts who’ll be asking questions about your product management experience,
+              including products that you’ve shipped and specific approaches or practices that you use
+            </li>
+            <li>
+              <p class="callout_subtitle">Researcher or designer</p>
+              45–60 minutes presenting one or two examples from your portfolio,
+              and 20–30 minutes answering questions
+            </li>
+            <li>
+              <p class="callout_subtitle">Software engineer or DevOps engineer</p>
+              A coding and coaching exercise for the majority of the interview
+            </li>
+            <li>
+              <p class="callout_subtitle">Data scientist or data engineer</p>
+              60 minutes or more conversation about your experience and knowledge of interacting with data at all stages
+              of its lifecycle,
+              as well as some questions that test your experience with Python, SQL, and/or data analytics (no whiteboard
+              coding questions)
+            </li>
+            <li>
+              <p class="callout_subtitle">Engagement manager</p>
+              Meeting with other engagement management experts who'll be asking questions about your experience
+              leading and managing agile, cross-functional delivery teams within a client service environment
+            </li>
+            <li>
+              <p class="callout_subtitle">Business strategy and operations</p>
+              Meeting with people who may not have experience in your discipline,
+              but whose work will closely intersect with yours
+            </li>
+          </ul>
+        </div>
+        <p>
+          We’ll send you an email a few days prior to the interview with more details so you know how to prepare.
+          Afterwards, your Skylight interviewers will share their notes with our hiring team.
+          If you’re a good fit for our open roles, we’ll schedule you for a behavioral interview.
+        </p>
 
         <div class="interview-explanation">
-          <h3>Interview steps</h3>
-
-          <p>
-            After you submit your application, we’ll evaluate your information
-            against the qualifications of our open positions. If you look like a
-            potential match, we’ll begin the interview process and communicate
-            the next steps.
-          </p>
-
-          <h4>1. Preliminary screening</h4>
-          <p>
-            The interview process begins with a 15-minute preliminary screening.
-            We’ll send you an email beforehand with background information about
-            Skylight. Plan to talk about your skills and experience and what
-            you’re passionate about. The call will also cover the interview
-            process and basic employment requirements.
-          </p>
-          <p>
-            Hiring managers will review notes from the screening, your resume,
-            and portfolio (if applicable). If it’s a good fit, we’ll schedule
-            you for a skills interview.
-          </p>
-
-          <h4>2. Skills interview</h4>
-          <p>
-            The skills interview runs between 60 and 90 minutes. You’ll meet
-            with two interviewers with experience in your discipline. They’ll
-            ask a variety of questions about your experience and skills, and how
-            you’d apply them within the context of Skylight’s work. We’ll leave
-            you with 10–15 minutes at the end for your questions.
-          </p>
-        </div>
-      </div>
-
-      <div class="callout--tip left-justified-list">
-        <p class="callout_title">What to expect, by role:</p>
-        <ul class="">
-          <li>
-            <p class="callout_subtitle">Product manager</p>
-            Meeting with other product experts who’ll be asking questions about your product management experience, 
-            including products that you’ve shipped and specific approaches or practices that you use
-          </li>
-          <li>
-            <p class="callout_subtitle">Researcher or designer</p>
-            45–60 minutes presenting one or two examples from your portfolio,
-            and 20–30 minutes answering questions
-          </li>
-          <li>
-            <p class="callout_subtitle">Software engineer or DevOps engineer</p>
-            A coding and coaching exercise for the majority of the interview
-          </li>
-          <li>
-            <p class="callout_subtitle">Data scientist or data engineer</p>
-            60 minutes or more conversation about your experience and knowledge of interacting with data at all stages of its lifecycle, 
-            as well as some questions that test your experience with Python, SQL, and/or data analytics (no whiteboard coding questions)
-          </li>
-          <li>
-            <p class="callout_subtitle">Engagement manager</p>
-            Meeting with other engagement management experts who'll be asking questions about your experience 
-            leading and managing agile, cross-functional delivery teams within a client service environment
-          </li>
-          <li>
-            <p class="callout_subtitle">Business strategy and operations</p>
-            Meeting with people who may not have experience in your discipline,
-            but whose work will closely intersect with yours
-          </li>
-        </ul>
-      </div>
-      <p>
-            We’ll send you an email a few days prior to the interview with more details so you know how to prepare. 
-            Afterwards, your Skylight interviewers will share their notes with our hiring team. 
-            If you’re a good fit for our open roles, we’ll schedule you for a behavioral interview. 
-        </p>
-      
-      <div class="interview-explanation">
           <h4>3. Behavioral interview</h4>
           <p>
-            The behavioral interview lasts for one hour. The intent is to assess whether or not you’d be a good fit for Skylight’s values and standards of behavior. 
-            You’ll meet with two interviewers who will ask questions about how you communicate, collaborate, and how you approach challenging situations at work. 
-            We’ll leave you with 10–15 minutes at the end for your questions. 
+            The behavioral interview lasts for one hour. The intent is to assess whether or not you’d be a good fit for
+            Skylight’s values and standards of behavior.
+            You’ll meet with two interviewers who will ask questions about how you communicate, collaborate, and how you
+            approach challenging situations at work.
+            We’ll leave you with 10–15 minutes at the end for your questions.
           </p>
           <p>
-            There’s no formal preparation needed for this interview, 
-            but we’ll send you an email a few days prior to the interview with more details so you know exactly what to expect. 
+            There’s no formal preparation needed for this interview,
+            but we’ll send you an email a few days prior to the interview with more details so you know exactly what to
+            expect.
           </p>
-      
+
           <h4>4. Additional interviews (if needed)</h4>
           <p>
-            In some cases, we’ll conduct additional interviews to evaluate areas we’d like to know more about. 
-            At this stage, we’ll also give you the opportunity to meet with potential teammates and ask additional questions, 
-            so you can make an informed decision on whether or not you’d like to move forward. 
+            In some cases, we’ll conduct additional interviews to evaluate areas we’d like to know more about.
+            At this stage, we’ll also give you the opportunity to meet with potential teammates and ask additional
+            questions,
+            so you can make an informed decision on whether or not you’d like to move forward.
           </p>
-      
+
           <h4>5. The offer</h4>
           <p>
-            If all the interviews go well, you’ll receive a preliminary offer followed by an official offer, 
+            If all the interviews go well, you’ll receive a preliminary offer followed by an official offer,
             which will include an agreed-upon start date. Congratulations!
           </p>
         </div>
-   
-      
+
+
         <div class="interview-explanation">
           <h3>Internships and apprenticeships</h3>
-          
-           <p>
-            If you’re applying for an internship or apprenticeship, you’ll go through a shorter process. 
+
+          <p>
+            If you’re applying for an internship or apprenticeship, you’ll go through a shorter process.
           </p>
-           <p>
-            First, submit your application. If you’re applying for a research or design role, 
-            please include a portfolio of 1–2 showcase projects, if you have one. 
-            Your portfolio can be anything from a website to a slide deck (whatever works for you). 
+          <p>
+            First, submit your application. If you’re applying for a research or design role,
+            please include a portfolio of 1–2 showcase projects, if you have one.
+            Your portfolio can be anything from a website to a slide deck (whatever works for you).
             Please ensure that you either remove the password to your portfolio or provide access details.
           </p>
           <p>
-            If you look like a potential match, we’ll do a preliminary screening. 
-            Plan to talk about your interests, experiences, and what you hope to get out of an internship or apprenticeship at Skylight. 
-          </p>
-           <p>
-            The next step is a 60-minute skills interview, where you’ll meet with one interviewer with experience in your discipline. 
-             They’ll ask a variety of questions about your experience and skills, 
-             and how you’d apply them within the context of an internship or apprenticeship at Skylight. 
-             We’ll leave you with 10–15 minutes at the end for your questions. 
+            If you look like a potential match, we’ll do a preliminary screening.
+            Plan to talk about your interests, experiences, and what you hope to get out of an internship or
+            apprenticeship at Skylight.
           </p>
           <p>
-            Finally, if you’re selected for an internship or apprenticeship, you’ll receive an offer! 
-            We’ll decide on a start date based on when we're able to onboard a class of interns or apprentices together. 
+            The next step is a 60-minute skills interview, where you’ll meet with one interviewer with experience in
+            your discipline.
+            They’ll ask a variety of questions about your experience and skills,
+            and how you’d apply them within the context of an internship or apprenticeship at Skylight.
+            We’ll leave you with 10–15 minutes at the end for your questions.
           </p>
-       </section>
+          <p>
+            Finally, if you’re selected for an internship or apprenticeship, you’ll receive an offer!
+            We’ll decide on a start date based on when we're able to onboard a class of interns or apprentices together.
+          </p>
+        </div>
+        {% include open_positions.html%}
+    </section>
   </div>
-</div>
 
-{% include intro_cta.html %}
+  {% include intro_cta.html %}


### PR DESCRIPTION
The iframe of open positions is loaded dynamically, this throws off the anchor links.

Moving open positions to the bottom fixes this because it allows the page to expand downward without the position on the page being thrown off. 