### PR TITLE
Removing greenhouse iframe margin-bottom hack

### DIFF
--- a/_sass/pages/_accessibility_toolkit.scss
+++ b/_sass/pages/_accessibility_toolkit.scss
@@ -123,9 +123,7 @@ p code {
 }
 
 #grnhse_app > iframe {
-  // greenhouse is adding 150px of space on the bottom of their job iframe
-  // and this is how we have to hack it. Sorry!
-  margin-bottom: -150px;
+  margin-bottom: 0px;
 }
 
 iframe {


### PR DESCRIPTION
Now that Greenhouse has updated the way it imbeds open positions in the iframe, we need to remove the `margin-bottom: -150px` because it's breaking the layout.