### PR TITLE
Fix cms_chart_model permalink to match slug convention

### DIFF
--- a/_projects/cms_chart_model.md
+++ b/_projects/cms_chart_model.md
@@ -2,7 +2,9 @@
 layout: default
 title_tag: "Centers for Medicare & Medicaid Services"
 title: "Turning data into decisions for rural hospitals"
-permalink: /work/experience/cms_chart_model/
+permalink: /work/experience/cms-chart-model/
+redirect_from:
+  - /work/experience/cms_chart_model/
 image: /img/projects/cms_chart_model/idos.svg
 image_description: "On the left, a doctor checks a patient's heartbeat. On the right, the same person walks a dog outside."
 feature_image:


### PR DESCRIPTION
Changes permalink from /work/experience/cms_chart_model/ (underscores) to /work/experience/cms-chart-model/ to match the site's /work/experience/<slug>/ convention where <slug> is lowercase-hyphenated. Adds redirect_from for the old underscore URL so existing inbound links continue to work.