### PR TITLE
Replace nav focus ring with on-brand, keyboard-only outline

### DIFF
--- a/_sass/layout/_header.scss
+++ b/_sass/layout/_header.scss
@@ -265,13 +265,17 @@
   }
 }
 
-// Restore dropdown focus browser default style
 .dropdown-toggle {
   border-radius: 0.25rem;
   font-family: $font-family-mono;
 
   &:focus {
-    outline: 5px auto -webkit-focus-ring-color;
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $brand-primary;
+    outline-offset: 3px;
   }
 
   &::after {


### PR DESCRIPTION
## Summary
- Swaps the default browser focus ring on `.dropdown-toggle` (Company/Work/Careers/Thoughts/Connect) for a 2px Skylight-blue outline
- Gated on `:focus-visible` so the ring only appears for keyboard navigation — no more box after a mouse click
- Maintains WCAG 2.1 SC 2.4.7 (Focus Visible) compliance for keyboard users

## Test plan
- [ ] Click a nav dropdown with mouse → no outline
- [ ] Tab to a nav dropdown with keyboard → 2px blue outline with 3px offset
- [ ] Dropdown menu still opens on both click and keyboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)