### PR TITLE
Enable skylight-hub plugin marketplace

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+settings.local.json

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "extraKnownMarketplaces": {
+    "skylight-hub": {
+      "source": {
+        "source": "github",
+        "repo": "skylight-hq/skylight-hub"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "website-case-study-writer@skylight-hub": true,
+    "content-style-linters@skylight-hub": true,
+    "content-respectful-language@skylight-hub": true,
+    "content-voice-and-tone@skylight-hub": true,
+    "content-channel-writers@skylight-hub": true
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` registering the `skylight-hq/skylight-hub` Claude Code marketplace and enabling the five plugins relevant to this repo: `website-case-study-writer`, `content-style-linters`, `content-respectful-language`, `content-voice-and-tone`, `content-channel-writers`.
- `content-govcon` is intentionally omitted — not applicable to skylight.digital content.
- Adds `.claude/.gitignore` so each contributor's `settings.local.json` (personal permission grants) stays out of git.

## Test plan
- [ ] Open this repo in Claude Code; verify the marketplace prompt appears and trust resolves via existing `gh` creds.
- [ ] `/plugin` lists the 5 enabled plugins as active.
- [ ] Running the case-study linter skill works end-to-end on a `_projects/*.md` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)