### PR TITLE
Rename enabled plugin: website-case-study-writer -> website-case-study

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "extraKnownMarketplaces": {
+    "skylight-hub": {
+      "source": {
+        "source": "github",
+        "repo": "skylight-hq/skylight-hub"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "website-case-study@skylight-hub": true,
+    "content-style-linters@skylight-hub": true,
+    "content-respectful-language@skylight-hub": true,
+    "content-voice-and-tone@skylight-hub": true,
+    "content-channel-writers@skylight-hub": true
+  }
+}


### PR DESCRIPTION
## Summary

Tracks the plugin rename in [skylight-hub#15](https://github.com/skylight-hq/skylight-hub/pull/15). The `website-case-study-writer` plugin was renamed to `website-case-study` (v0.4.0) because it bundles a writer, linter, and interviewer — the singular role suffix was misleading, and the new name follows the repo''s [naming conventions](https://github.com/skylight-hq/skylight-hub/blob/main/standards/naming-conventions.md).

## Changes

- `.claude/settings.json`: `website-case-study-writer@skylight-hub` → `website-case-study@skylight-hub` in `enabledPlugins`.

Skill names inside the plugin are unchanged, so any references in local prompts or docs to `website-case-study-writer` (the skill) still work.

## Test plan

- [ ] Wait for skylight-hub#15 to merge
- [ ] Pull this branch locally; run `/plugin marketplace update skylight-hub` in Claude Code; confirm the renamed plugin loads
- [ ] Confirm the three skills (`website-case-study-writer`, `website-case-study-linter`, `website-case-study-interviewer`) are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)