### PR TITLE
Enable renamed Skylight plugins (scope taxonomy)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,10 +8,10 @@
     }
   },
   "enabledPlugins": {
-    "website-case-study@skylight-hub": true,
+    "skylight-website-case-study@skylight-hub": true,
     "content-style-linters@skylight-hub": true,
-    "content-respectful-language@skylight-hub": true,
-    "content-voice-and-tone@skylight-hub": true,
-    "content-channel-writers@skylight-hub": true
+    "skylight-respectful-language@skylight-hub": true,
+    "skylight-voice-and-tone@skylight-hub": true,
+    "skylight-channel-writers@skylight-hub": true
   }
 }


### PR DESCRIPTION
## Summary

Tracks [skylight-hub#17](https://github.com/skylight-hq/skylight-hub/pull/17), which added a scope taxonomy to the marketplace. Four plugins gained the \`skylight-\` prefix to signal they encode Skylight voice:

| Old | New |
|---|---|
| \`website-case-study\` | \`skylight-website-case-study\` |
| \`content-respectful-language\` | \`skylight-respectful-language\` |
| \`content-voice-and-tone\` | \`skylight-voice-and-tone\` |
| \`content-channel-writers\` | \`skylight-channel-writers\` |

\`content-style-linters\` is unchanged (scope: \`reusable\`).

## Test plan

- [ ] Pull this branch locally; run \`/plugin marketplace update skylight-hub\` in Claude Code; confirm the four renamed plugins load and skills are available
- [ ] Run an existing case-study workflow end-to-end as a smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)