### PR TITLE
Fix 4 pre-existing corpus blockers

### DIFF
--- a/_projects/cdc_dibbs_cloud_enablement.md
+++ b/_projects/cdc_dibbs_cloud_enablement.md
@@ -68,10 +68,10 @@ practices:
   - "Hybrid-cloud architecture"
   - "Virtual collaboration"
   - "Remote teams"
+news_posts:
 project_url: https://dibbs.tools
 project_cta: "See the tools"
 source_code_url: https://github.com/CDCgov/dibbs-cloud
-news_posts:
 ---
 
 {% capture summary %}

--- a/_projects/cdc_dibbs_ecr_viewer.md
+++ b/_projects/cdc_dibbs_ecr_viewer.md
@@ -86,10 +86,10 @@ practices:
   - "Cloud hosting"
   - "Hybrid-cloud architecture"
   - "Virtual collaboration"
+news_posts:
 project_url: https://dibbs.tools
 project_cta: "See the tools"
 source_code_url: https://github.com/CDCgov/dibbs-ecr-viewer
-news_posts:
 ---
 
 {% capture summary %}

--- a/_projects/ct_ece_reporter.md
+++ b/_projects/ct_ece_reporter.md
@@ -3,10 +3,10 @@ layout: default
 title_tag: "State of Connecticut"
 title: "Building a trusted enrollment data foundation for early childhood programs"
 permalink: /work/experience/ct-ece-reporter/
-feature_image: /img/projects/ct_ece_reporter/ece-reporter.gif
-feature_image_description: "Animated view of the ECE Reporter dashboard and monthly reporting workflow."
 image: /img/projects/ct_ece_reporter/ece-reporter.svg
 image_description: "A teacher sitting with a young child at a table and a computer screen in the background showing a green checkmark."
+feature_image: /img/projects/ct_ece_reporter/ece-reporter.gif
+feature_image_description: "Animated view of the ECE Reporter dashboard and monthly reporting workflow."
 feature_image_shadow: true
 order: 210
 display: true

--- a/_projects/usaf_bespin_transformation_support.md
+++ b/_projects/usaf_bespin_transformation_support.md
@@ -8,7 +8,7 @@ image_description: "A uniformed crew work on a scaffold to build a giant mobile 
 feature_image:
 feature_image_description:
 feature_image_shadow:
-order: 1150
+order: 1149
 display: true
 tags:
   - "transformation"


### PR DESCRIPTION
## Summary
Surgical fix for 4 pre-existing case-study linter blockers identified in a corpus-wide lint sweep. All four are structural issues unrelated to any active rewrite work.

**Result:** all 64 case studies in \`_projects/\` now lint clean of blocking findings — first time the corpus has been blocker-free.

## Fixes

| File | Issue | Fix |
|---|---|---|
| \`usaf_bespin_transformation_support.md\` | \`order_duplicate\` — both this file and \`cms_chart_model.md\` were at \`order: 1150\` | Bumped to \`order: 1149\` (umbrella file → display one slot earlier; arbitrary tie-breaker, can be re-ordered later) |
| \`cdc_dibbs_cloud_enablement.md\` | \`frontmatter_order\` — \`news_posts\` was at end after \`source_code_url\` | Moved \`news_posts\` to its canonical position before \`project_url\` |
| \`cdc_dibbs_ecr_viewer.md\` | Same as above | Same fix |
| \`ct_ece_reporter.md\` | \`frontmatter_order\` — \`feature_image\` block was BEFORE \`image\` block | Swapped — \`image\` first, then \`feature_image\` per canonical order |

## Verification
- Ran the case-study linter across all 64 \`_projects/*.md\` files. **0 blockers remaining.**
- Remaining advisories are pre-existing style issues (long sentences, reading grade) tracked separately in the rewrite queue.

## Notes
- The \`cms_chart_model.md\` permalink issue I'd flagged earlier in this session was actually already resolved (hyphenated permalink + \`redirect_from\` to the legacy underscored form) — no change needed there.
- The previously-flagged \`unknown_team_member\` blockers were already resolved by [#462](https://github.com/skylight-hq/skylight.digital/pull/462).

🤖 Generated with [Claude Code](https://claude.com/claude-code)