### PR TITLE
Add Claude Code local files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ Gemfile.lock
 
 # Local Netlify folder
 .netlify
+
+# Claude Code local files
+.claude/launch.json
+.claude/worktrees/
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
Adds three Claude Code paths to `.gitignore` that are specific to each contributor's local environment and should never be committed:

- `.claude/launch.json` — Jekyll preview config (often has hardcoded Ruby paths for the contributor's machine)
- `.claude/worktrees/` — ephemeral session worktrees
- `.claude/settings.local.json` — per-contributor permission grants

## Why
Three times this session I had to clean these out of accidental commits during automated git operations. Proactive ignore prevents the recurrence.

## What stays tracked
- `.claude/settings.json` — the shared marketplace config (already committed in [#456](https://github.com/skylight-hq/skylight.digital/pull/456))
- `.claude/.gitignore` — the in-dir ignore that scopes `settings.local.json` out

🤖 Generated with [Claude Code](https://claude.com/claude-code)