### PR TITLE
Rewrite USAF BIFROST case study using website-case-study-writer skill v0.9.2

### DIFF
--- a/_projects/usaf_wxpo_bifrost.md
+++ b/_projects/usaf_wxpo_bifrost.md
@@ -23,7 +23,7 @@ tags:
   - "jennifer herzberg"
   - "laura kerry"
   - "kyle planeaux"
-excerpt: "Redesigning critical weather workflows within BIFROST — the Air Force's consolidated weather platform — while embedding the research and design practices needed to sustain the work."
+excerpt: "Redesigning critical weather workflows within BIFROST — the Air Force’s consolidated weather platform — while embedding the research and design practices needed to sustain the work."
 project_members:
   - taylor-graue
   - holly-dewolf
@@ -65,39 +65,39 @@ source_code_url:
 ---
 
 {% capture summary %}
-As part of our [work modernizing weather intelligence delivery for the Air Force](/work/experience/usaf-wxpo-weather-modernization/), we're redesigning critical workflows within BIFROST — the Weather Systems Program Office (WxPO)'s consolidated platform for weather applications. Building on the [design capability we've established in WARPspeed](/work/experience/usaf-wxpo-warpspeed/), we're improving usability and accessibility for forecasters, pilots, and mission planners while embedding the research practices needed to sustain continuous improvement.
+As part of our [work modernizing weather intelligence delivery for the Air Force](/work/experience/usaf-wxpo-weather-modernization/), we’re redesigning critical workflows within BIFROST. It’s the Weather Systems Program Office (WxPO)’s consolidated platform for weather applications. Building on the [design capability we established in WARPspeed](/work/experience/usaf-wxpo-warpspeed/), we’re improving usability and accessibility for forecasters, pilots, and mission planners. We’re also embedding the research practices that sustain continuous improvement.
 {% endcapture %}
 
 {% capture challenge %}
-BIFROST was WxPO's answer to a fragmented portfolio: one platform to replace dozens of disconnected legacy tools. But consolidation raised the bar. BIFROST had to preserve essential functionality — like issuing Watches, Warnings, and Advisories through the Joint Environmental Toolkit (JET) and delivering pre-mission weather briefings — while streamlining workflows, standardizing patterns, and improving the overall user experience.
+BIFROST was WxPO’s answer to a fragmented portfolio: one platform to replace dozens of legacy tools. But consolidation raised the bar. BIFROST had to preserve essential functionality while streamlining workflows. That meant supporting Watches, Warnings, and Advisories through the Joint Environmental Toolkit (JET), delivering pre-mission weather briefings, and improving the overall user experience.
 
-The redesign couldn't succeed on good intentions alone. User feedback had historically arrived too late to shape requirements. The JET team, for example, collected input after features shipped — leading to reactive fixes, patchwork improvements, and mounting design debt. Users had grown skeptical that modernization would actually make their work easier.
+The redesign couldn’t succeed on good intentions alone. User feedback had historically arrived too late to shape requirements. The JET team, for example, collected input only after features shipped. The result was reactive fixes, patchwork improvements, and mounting design debt. Users had grown skeptical that modernization would actually make their work easier.
 
-With the [design practices and tooling we'd built into WARPspeed](/work/experience/usaf-wxpo-warpspeed/) now in place, WxPO engaged us to apply them to BIFROST's highest-impact workflows — proving that better design process could produce better products, and rebuilding trust with the user community in the process.
+With the [design practices and tooling we’d built into WARPspeed](/work/experience/usaf-wxpo-warpspeed/) now in place, WxPO engaged us to apply them to BIFROST’s highest-impact workflows. The goal: prove better design process could produce better products, and rebuild trust with users along the way.
 {% endcapture %}
 
 {% capture solution %}
-Improving user experiences requires more than redesigning features. It means helping WxPO deliver improvements faster while rebuilding trust with users whose work depends on reliable, time-sensitive tools. We pair hands-on redesign with support across research, design, content, and agile product management, focusing on five areas.
+Improving user experiences requires more than redesigning features. It means helping WxPO deliver improvements faster and rebuilding trust with users whose work depends on reliable, time-sensitive tools. We paired hands-on redesign with support across research, design, content, and agile product management — focusing on five areas.
 
-**A usability and accessibility audit established the baseline.** We audited BIFROST to pinpoint friction points and compliance gaps, documented the issues, and partnered with the product manager and developers to prioritize and address them. To reduce inconsistency across the growing ecosystem, we extended the WxPO design system with reusable templates in Figma, then trained designers on accessibility best practices, prototyping, and cleaner design handoffs.
+**A usability and accessibility audit established the baseline.** We audited BIFROST to pinpoint friction points and compliance gaps, then partnered with the product manager and developers to prioritize and address them. To reduce inconsistency across the growing ecosystem, we extended the WxPO design system with reusable Figma templates. We then trained designers on accessibility, prototyping, and cleaner design handoffs.
 
-**Regular touch points replaced the old pattern of occasional feedback cycles.** Continuous user engagement now spans discovery, design, and delivery — research sessions, standing meetings with volunteer users, and on-site visits that surface real use cases and shape feature requirements. Usability testing on prototypes modeled iterative delivery for both users and the BIFROST team. Coaching in research methods gave teammates the confidence to lead sessions independently.
+**Next, regular touch points replaced the old pattern of occasional feedback cycles.** Continuous user engagement now spans discovery, design, and delivery. Standing meetings with volunteer users and on-site visits surface real use cases and shape feature requirements. Usability testing on prototypes models iterative delivery for both users and the BIFROST team. Coaching in research methods gives teammates the confidence to lead sessions independently.
 
 {% include callout.html
   type = "pullquote"
   content = "These sessions that you guys are doing are extremely valuable — giving everybody the time to give you guys feedback, making this thing certainly a lot better."
 %}
 
-**Tighter design-to-development handoffs reduced a consistent source of rework.** We established a bi-weekly alignment between design and engineering to surface technical constraints early. Figma enabled richer prototypes, and we trained developers to use Figma dev tools for faster implementation. A Material UI component library in Figma reduced translation work between design and React code. Jira ticket standards ensured each issue linked to the relevant Figma design and included the detail needed to build with confidence — policy constraints, user requirements, acceptance criteria, and edge cases.
+**To reduce a consistent source of rework, we tightened the design-to-development handoff.** A bi-weekly alignment between design and engineering surfaces technical constraints early. Figma enables richer prototypes, and we trained developers to use Figma dev tools for faster implementation. A Material UI component library in Figma cut translation work between design and React code. Jira ticket standards now ensure each issue links to the relevant Figma design. Each ticket also includes the detail needed to build with confidence — policy constraints, user requirements, acceptance criteria, and edge cases.
 
 {% include callout.html
   type = "pullquote"
   content = "The designers are able to help align the requirements and user desires into a cohesive user interface design that makes the product look more polished and aids in the development process by bringing user needs and design to the front of the development effort."
 %}
 
-**With these foundations in place, we redesigned BIFROST's highest-impact workflows.** Watches, Warnings, and Advisories and Mission Management — the application for requesting and completing mission briefings — both got end-to-end redesigns that streamlined core operations for the weather community and supported faster, more confident mission planning.
+**With these foundations in place, we redesigned BIFROST’s highest-impact workflows.** Watches, Warnings, and Advisories — and Mission Management, the application for requesting and completing mission briefings — both got end-to-end redesigns. Each streamlined core operations for the weather community and supported faster, more confident mission planning.
 
-**User-centered training and product guidance supported adoption across the user base.** After interviewing users about onboarding and learning needs, we developed content guidelines tailored to the ecosystem, used them to update and standardize nearly 40 written training guides, and provided training in the formats most valuable to users — including videos and live virtual sessions.
+Finally, user-centered training and product guidance supported adoption across the user base. After interviewing users about onboarding and learning needs, we developed content guidelines tailored to the ecosystem. We used them to update and standardize nearly 40 written training guides. We then delivered training in the formats users valued most — including videos and live virtual sessions.
 {% endcapture %}
 
 {% capture results %}
@@ -105,7 +105,7 @@ Improving user experiences requires more than redesigning features. It means hel
 - **Embedded repeatable user research practices** across discovery, design, and delivery — coaching teammates to lead sessions independently and rebuilding trust with a previously skeptical user community
 - **Improved design-to-development handoffs** through bi-weekly alignment, Jira ticket standards, and a Material UI component library in Figma, reducing rework across releases
 - **Updated nearly 40 training guides** to support self-service onboarding and faster adoption of BIFROST
-- **Building internal design capacity** through ongoing training on accessibility best practices, prototyping, and modern design workflows
+- **Built internal design capacity** through ongoing training on accessibility, prototyping, and modern design workflows
 {% endcapture %}
 
 {% include project.html


### PR DESCRIPTION
## Summary
- Applies the v0.9.2 opener-variety lesson to the BIFROST case study: varies the five bolded paragraph openers across noun+verb, fronted clause, and inverted clause shapes, and drops bold on the final paragraph to break the 5/5 density pattern.
- Reduces approximate Flesch-Kincaid grade from 17 to 13.8 by splitting long sentences (proper nouns like Joint Environmental Toolkit and Watches, Warnings, and Advisories keep the floor above the 10 target).
- Curls apostrophes throughout.

## Test plan
- [x] `lint_case_study.rb` schema check is clean
- [x] `core_style_lint.rb` is clean
- [x] `word_list_lint.rb` is clean
- [x] `plain_language_metrics_lint.rb` grade dropped from 17 → 13.8
- [x] Local preview renders at `/work/experience/usaf-wxpo-bifrost/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)