### PR TITLE
Rewrite NCoC refugee admissions research case study using website-case-study-writer skill

### DIFF
--- a/_projects/ncoc_refugee_admissions_research.md
+++ b/_projects/ncoc_refugee_admissions_research.md
@@ -41,7 +41,7 @@ source_code_url:
 ---
 
 {% capture summary %}
-The U.S. Refugee Admissions Program (USRAP) roadmap is a 50-page report that gave the incoming Biden administration practical, evidence-based recommendations for rebuilding the nation's refugee resettlement infrastructure. Developed with the [Penn Biden Center](https://global.upenn.edu/penn-washington/) (now Penn Washington) and the [National Conference on Citizenship](https://ncoc.org/) (NCoC), the roadmap centered refugee voices alongside policy, operational, and data analysis to chart a path toward admitting 125,000 refugees by FY2022.
+The U.S. Refugee Admissions Program (USRAP) roadmap is a 50-page report that gave the incoming Biden administration practical, evidence-based recommendations for rebuilding the nation’s refugee resettlement infrastructure. We developed it with the [Penn Biden Center](https://global.upenn.edu/penn-washington/) (now Penn Washington) and the [National Conference on Citizenship](https://ncoc.org/) (NCoC). The roadmap centered refugee voices alongside policy, operational, and data analysis to chart a path toward admitting 125,000 refugees by fiscal year 2022 (FY2022).
 {% endcapture %}
 
 {% capture challenge %}
@@ -52,35 +52,35 @@ The U.S. Refugee Admissions Program (USRAP) roadmap is a 50-page report that gav
   cite_title = "resettled in 2015"
 %}
 
-From 2016 to 2020, refugee admissions under USRAP fell to historic lows. During that period, many of the programs and institutional supports required to resettle refugees in the United States were significantly weakened or dismantled. The infrastructure that once processed tens of thousands of cases per year had atrophied — resettlement agencies closed offices, trained staff moved on, and the pipeline of approved refugees stalled.
+From 2016 to 2020, refugee admissions under USRAP fell to historic lows. During that period, many of the programs and institutional supports required to resettle refugees were significantly weakened or dismantled. The infrastructure that once processed tens of thousands of cases per year had atrophied. Resettlement agencies closed offices, trained staff moved on, and the pipeline of approved refugees stalled.
 
-The refugee experience was difficult at nearly every stage. Overseas, refugees could wait years in camps or temporary settings with limited access to work, medical care, information, and personal safety. While moving through the admissions process, many had little visibility into the status of their case and often lived in uncertainty for years. After arrival in the United States, challenges continued — unless refugees had a friend or family member already living here, they had little say in where they'd be resettled. Government support was limited, and many families had to navigate housing, employment, transportation, education, and health needs with minimal time and assistance.
+The refugee experience was difficult at nearly every stage. Overseas, refugees could wait years in camps or temporary settings with limited access to work, medical care, information, and personal safety. While moving through the admissions process, many had little visibility into the status of their case and lived in uncertainty for years. Challenges continued after arrival. Unless refugees had a friend or family member already in the U.S., they had little say in where they’d be resettled. Government support was limited, and many families had to navigate housing, employment, transportation, education, and health needs with minimal time and help.
 
 {% include callout.html
   type = "pullquote"
   content = "What was challenging when I first arrived? Everything."
 %}
 
-At the same time, many policymakers — including some who worked in and around refugee policy — lacked a full picture of the end-to-end refugee admissions and resettlement experience. Individual officials often understood their slice of the process but couldn't see how the pieces connected or where handoffs failed. Rebuilding the program required not only policy change, but a clearer understanding of where the system was failing refugees in practice.
+At the same time, many policymakers lacked a full picture of the end-to-end refugee admissions and resettlement experience. Individual officials understood their slice of the process but couldn’t see how the pieces connected or where handoffs failed. Rebuilding the program required not just policy change, but a clearer understanding of where the system was failing refugees in practice.
 {% endcapture %}
 
 {% capture solution %}
-Rebuilding a program that had processed tens of thousands of cases per year couldn't start with policy levers alone — it had to start with the people the system was supposed to serve. Led by Ariana Berengaut of the Penn Biden Center and Eric Hysen of NCoC, our team took a user-centered approach to developing recommendations that could support the goal of admitting 125,000 refugees in FY2022, up from roughly 15,000 in 2020.
+Rebuilding a program that had processed tens of thousands of cases per year couldn’t start with policy levers alone. It had to start with the people the system was supposed to serve. Led by Ariana Berengaut of the Penn Biden Center and Eric Hysen of NCoC, our team took a user-centered approach to developing recommendations that could support the goal of admitting 125,000 refugees in FY2022, up from roughly 15,000 in 2020.
 
-**The research began with dozens of trauma-informed interviews.** Across video calls, we spoke with people involved in refugee policy, operations, advocacy, and implementation, as well as refugees who had personally experienced the admissions and resettlement journey. Trauma-informed interviewing techniques helped us gather candid insight into what made the process difficult, where it broke down, and what changes could most improve outcomes for refugees and their families.
+**The research began with dozens of trauma-informed interviews.** Across video calls, we spoke with people involved in refugee policy, operations, advocacy, and implementation. We also spoke with refugees who had personally experienced the admissions and resettlement journey. Trauma-informed interviewing techniques helped us gather candid insight into what made the process difficult, where it broke down, and what changes could most improve outcomes for refugees and their families.
 
-Publicly available data provided the quantitative complement — helping us identify refugee populations, understand processing barriers, and **model the potential impact of proposed recommendations.** Combining the two approaches ensured that our recommendations reflected both human experience and operational reality.
+Publicly available data provided the quantitative complement. It helped us identify refugee populations, understand processing barriers, and **model the potential impact of proposed recommendations.** Combining the two approaches grounded our recommendations in both human experience and operational reality.
 
 The research produced **concrete action plans organized into 100-day, one-year, and two-to-four-year strategies.** Recommendations included:
 
-- Expanding the use of virtual interviews for follow-up interviews and hard-to-reach refugee populations
-- Prioritizing the completion of security checks for refugees who'd been stuck in the pipeline for years after interviewing
+- Expanding the use of virtual interviews for follow-up sessions and hard-to-reach refugee populations
+- Prioritizing the completion of security checks for refugees who’d been stuck in the pipeline for years after interviewing
 - Developing a refugee-informed algorithmic approach to determine where refugees are resettled in the U.S.
 - Expanding the scale and scope of resettlement support
 - Guaranteeing six months of housing support for all refugees, rather than limiting support based on employability or health conditions
 - Giving resettlement agencies and states greater flexibility in how funding could be used to meet diverse refugee needs
 
-Because policymakers often worked on only one part of the system, we also created a **journey map showing the full refugee admissions and resettlement experience from the perspective of a refugee.** This artifact made the end-to-end process — and its pain points — visible in a way many stakeholders had never seen before, becoming a tool for building shared understanding across agencies and advocacy organizations.
+Because policymakers often worked on only one part of the system, we also created a **journey map showing the full refugee admissions and resettlement experience from the perspective of a refugee.** This artifact made the end-to-end process — and its pain points — visible in a way many stakeholders had never seen before. It became a tool for building shared understanding across agencies and advocacy organizations.
 
 ![A journey map of the refugee admission experience.](/img/projects/ncoc_refugee_admissions_research/refugee-admission-journey-map.png){: .my-0 }
 {: .border .p-3 }
@@ -90,11 +90,11 @@ Source: Penn Biden Center/NCoC
 {% endcapture %}
 
 {% capture results %}
-- **Conducted more than 100 interviews** with policy experts, operators, advocates, and refugees who experienced the admissions process firsthand, grounding the roadmap in lived experience
+- **Conducted more than 100 interviews** with policy experts, operators, advocates, and refugees who experienced the admissions process firsthand — grounding the roadmap in lived experience
 - **Produced a [50-page report](https://ncoc.org/wp-content/uploads/2020/10/Final-Report-A-Roadmap-to-Rebuilding-USRAP.pdf)** outlining a concrete, phased roadmap for rebuilding USRAP across 100-day, one-year, and two-to-four-year horizons
 - **Published a [complementary paper](https://www.ncoc.org/wp-content/uploads/2020/10/Restoring-U.S.-Global-Leadership-on-Refugee-Protection-1.pdf)** proposing an agenda for restoring U.S. global leadership on refugee protection
 - **Created a journey map** of the refugee admissions experience from the perspective of a refugee, helping policymakers visualize the full end-to-end process and its pain points
-- **Informed administration hiring and policy implementation** — two project leads later joined the Biden administration in roles positioned to carry the recommendations forward: Eric Hysen as Chief Information Officer at the Department of Homeland Security and Ariana Berengaut as Senior Advisor to the National Security Advisor
+- **Informed administration hiring and policy implementation** — two project leads later joined the Biden administration in roles positioned to carry the recommendations forward: Eric Hysen as Chief Information Officer at the Department of Homeland Security, and Ariana Berengaut as Senior Advisor to the National Security Advisor
 {% endcapture %}
 
 {% include project.html


### PR DESCRIPTION
## Summary
- Tightens prose: drops approximate Flesch-Kincaid grade from 14.3 to 12.2 and reduces long-sentence warnings from 8 to 3.
- Clears the passive-voice warning (was 17%).
- Curls apostrophes; expands FY2022 to "fiscal year 2022 (FY2022)" on first use; swaps "assistance" for "help" per the word list.
- Preserves the existing mid-paragraph emphasis pattern with varied opener shapes (per writer skill v0.9.2).

Pre-existing taxonomy warnings (Policy research, Trauma-informed interviewing, Quantitative analysis, Airtable, Excel) were left unchanged — these terms are accurate to this engagement and not introduced by this PR.

## Test plan
- [x] Schema lint clean
- [x] Core style lint clean
- [x] Word list lint clean
- [x] Acronym lint clean
- [x] Grade 14.3 → 12.2
- [x] Local preview renders at `/work/experience/ncoc-refugee-admissions-research/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)