### PR TITLE
Rewrite CMS CMMI IDOS case study using website-case-study-writer skill

### DIFF
--- a/_projects/cms_cmmi_idos.md
+++ b/_projects/cms_cmmi_idos.md
@@ -58,21 +58,21 @@ source_code_url:
 ---
 
 {% capture summary %}
-The Center for Medicare & Medicaid Innovation (CMMI) relies on a portfolio of technology systems to design, test, and scale healthcare payment and delivery models. We partnered with CMMI's Innovation Development and Operation Services (IDOS) program to bring user-centered design and modern digital delivery practices to those systems — helping teams better understand their users, improve usability, and make more informed decisions.
+The Center for Medicare & Medicaid Innovation (CMMI) relies on a portfolio of technology systems to design, test, and scale healthcare payment and delivery models. We partnered with CMMI’s Innovation Development and Operation Services (IDOS) program to bring user-centered design and modern digital delivery practices to those systems. The goal: help teams better understand their users, improve usability, and make more informed decisions.
 {% endcapture %}
 
 {% capture challenge %}
-CMMI runs dozens of payment and delivery models aimed at improving healthcare outcomes and reducing costs for Medicare, Medicaid, and Children's Health Insurance Program beneficiaries across the United States. Each model depends on technology systems to collect data from participants, analyze results, and share findings. Because the stakes are high — model participation is often voluntary — the usability of those systems directly affects whether providers engage and whether CMMI can draw meaningful conclusions from the data.
+CMMI runs dozens of payment and delivery models aimed at improving healthcare outcomes and reducing costs for Medicare, Medicaid, and Children’s Health Insurance Program beneficiaries. Each model depends on technology systems to collect data from participants, analyze results, and share findings. The stakes are high. Model participation is often voluntary, so the usability of those systems directly affects whether providers engage — and whether CMMI can draw meaningful conclusions from the data.
 
-Over time, however, many of CMMI's systems had evolved independently. Different teams built and maintained their own platforms without shared design standards, consistent data practices, or a common approach to understanding user needs. The result was a fragmented technology landscape: inconsistent interfaces that confused users, duplicated infrastructure that increased technical complexity, and growing gaps between what teams needed from their systems and what those systems actually delivered.
+Over time, many of CMMI’s systems had evolved independently. Different teams built and maintained their own platforms without shared design standards, consistent data practices, or a common approach to understanding user needs. The result was a fragmented technology landscape: inconsistent interfaces that confused users, duplicated infrastructure that added technical complexity, and growing gaps between what teams needed and what their systems delivered.
 
-The deeper problem was structural. Teams lacked the methods and practices to surface real user needs or translate research findings into system improvements. Without embedded user research, design decisions were driven by assumptions rather than evidence — and CMMI had no systematic way to learn what providers and model participants actually wanted from its technology.
+The deeper problem was structural. Teams lacked the methods and practices to surface real user needs or translate research findings into system improvements. Without embedded user research, design decisions were driven by assumptions rather than evidence. CMMI had no systematic way to learn what providers and model participants actually wanted from its technology.
 {% endcapture %}
 
 {% capture solution %}
-Rather than starting with specific system fixes, **we began with a baseline assessment of CMMI's IT platforms** — evaluating maturity across user-centered design, agile delivery, and DevSecOps practices. The assessments gave CMMI a clear picture of where each platform stood, identified the highest-leverage gaps in usability and technical practices, and established a prioritized foundation for improvement.
+Rather than starting with specific system fixes, **we began with a baseline assessment of CMMI’s IT platforms** — evaluating maturity across user-centered design, agile delivery, and DevSecOps practices. The assessments gave CMMI a clear picture of where each platform stood. They identified the highest-leverage gaps in usability and technical practices, and established a prioritized foundation for improvement.
 
-With that diagnostic in hand, we embedded directly into platform teams. **Working alongside the Salesforce Connect team, we designed and executed a user research plan** that included interviews with healthcare providers. The research reached past layers of program administration to uncover how systems were actually used in practice — surfacing insights about provider needs that CMMI had never had the structural incentive or method to discover.
+With that diagnostic in hand, we embedded directly into platform teams. **Working alongside the Salesforce Connect team, we designed and ran a user research plan** that included interviews with healthcare providers. The research reached past layers of program administration to uncover how systems were actually used in practice. It surfaced insights about provider needs that CMMI had never had the structural incentive or method to discover.
 
 {% include callout.html
   type = "pullquote"
@@ -81,13 +81,13 @@ With that diagnostic in hand, we embedded directly into platform teams. **Workin
   cite_title = "CMMI"
 %}
 
-We conducted similar targeted research for the Enterprise Data Management Program (EDMP), helping teams understand engagement patterns and data needs across model participants. These findings **informed redesigned user interfaces for key systems such as the Centralized Data Exchange (CDX),** improving usability and enabling more effective data analysis. The improvements supported programs like the Emergency Triage, Treat, and Transport (ET3) model, where faster access to cleaner data helped teams make more timely decisions.
+We ran similar targeted research for the Enterprise Data Management Program (EDMP), helping teams understand engagement patterns and data needs across model participants. These findings **informed redesigned user interfaces for key systems such as the Centralized Data Exchange (CDX),** improving usability and enabling more effective data analysis. The improvements supported programs like the Emergency Triage, Treat, and Transport (ET3) model, where faster access to cleaner data helped teams make more timely decisions.
 
-Throughout the engagement, we focused on building capability, not just delivering artifacts. **We coached teams on user research methods, facilitated design workshops, and embedded iterative practices** — user interviews, usability testing, prototype-and-test cycles — so that the approach would persist after our engagement ended. The goal was a sustainable shift: from technology decisions driven by assumptions to decisions grounded in evidence from real users.
+Throughout the engagement, we focused on building capability — not just delivering artifacts. **We coached teams on user research methods, ran design workshops, and embedded iterative practices** — user interviews, usability testing, and prototype-and-test cycles. The goal was a sustainable shift: from technology decisions driven by assumptions to decisions grounded in evidence from real users.
 {% endcapture %}
 
 {% capture results %}
-- **Assessed platform maturity across CMMI's IT systems,** identifying gaps in usability, technical practices, and user alignment that informed a prioritized modernization roadmap
+- **Assessed platform maturity across CMMI’s IT systems,** identifying gaps in usability, technical practices, and user alignment that informed a prioritized modernization roadmap
 - **Uncovered user insights CMMI had never surfaced** by reaching through multiple administrative layers to interview healthcare providers and end users directly
 - **Redesigned user interfaces for the Centralized Data Exchange** and other key systems, improving usability and enabling more effective data analysis across model programs
 - **Embedded user-centered design practices** across multiple platform teams, establishing repeatable methods for user research, usability testing, and iterative design


### PR DESCRIPTION
## Summary
- Curls apostrophes; replaces "facilitated" / "conducted" with "ran" per the word list.
- Splits long sentences to drop approximate Flesch-Kincaid grade from 17.5 to 15.3 and long-sentence warnings from 10 to 5.
- Preserves the mid-paragraph emphasis pattern with varied bolded opener shapes per writer skill v0.9.2.

## Test plan
- [x] Schema lint clean
- [x] Core style lint clean
- [x] Word list lint clean
- [x] Acronym lint clean
- [x] Grade 17.5 → 15.3
- [x] Local preview renders at `/work/experience/cms-cmmi-idos/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)