### PR TITLE
Rewrite CT OEC website redesign case study using website-case-study-writer skill

### DIFF
--- a/_projects/ct_oec_website_redesign.md
+++ b/_projects/ct_oec_website_redesign.md
@@ -69,11 +69,11 @@ source_code_url:
 ---
 
 {% capture summary %}
-As part of our [digital transformation work](/work/experience/ct-oec-digital-transformation/) with the Connecticut Office of Early Childhood (OEC), we redesigned the agency's web presence into a single, user-focused experience with clear pathways to critical early childhood resources. The new site improved access to services relied on by more than 200,000 children and families across Connecticut.
+As part of our [digital transformation work](/work/experience/ct-oec-digital-transformation/) with the Connecticut Office of Early Childhood (OEC), we redesigned the agency’s web presence. The new site offers a single, user-focused experience with clear pathways to critical early childhood resources — improving access to services relied on by more than 200,000 children and families across Connecticut.
 {% endcapture %}
 
 {% capture challenge %}
-OEC's website served as the primary access point for families seeking child care, providers navigating licensing, and staff managing programs — but it wasn't meeting any of those audiences well. The site had grown organically over the years, resulting in a fragmented structure where critical information was buried behind confusing navigation, outdated forms, and jargon-heavy language.
+OEC’s website served as the primary access point for families seeking child care, providers navigating licensing, and staff managing programs. But it wasn’t meeting any of those audiences well. The site had grown organically over the years, resulting in a fragmented structure. Critical information was buried behind confusing navigation, outdated forms, and jargon-heavy language.
 
 {% include callout.html
   type = "pullquote"
@@ -85,13 +85,13 @@ The experience was desktop-only, shutting out the many families and providers wh
 {% endcapture %}
 
 {% capture solution %}
-**We started with extensive user research** to understand how families, child care providers, and OEC staff actually used the site — and where it fell short. Card sorting, tree testing, persona development, and usability testing revealed that the site's information architecture didn't match how any of its core audiences thought about early childhood services.
+**We started with extensive user research** to understand how families, child care providers, and OEC staff actually used the site — and where it fell short. Card sorting, tree testing, persona development, and usability testing revealed that the site’s information architecture didn’t match how any of its core audiences thought about early childhood services.
 
-**Those research findings shaped every design decision that followed.** We simplified navigation, rewrote content in plain language, and organized the site around the tasks users came to accomplish — things like finding a child care provider, applying for a license, or accessing program resources. The result was a single, user-focused homepage with clear pathways for each key audience, built to work across both mobile and desktop.
+**Those research findings shaped every design decision that followed.** We simplified navigation, rewrote content in plain language, and organized the site around the tasks users came to accomplish — finding a child care provider, applying for a license, or accessing program resources. The result was a single, user-focused homepage with clear pathways for each key audience, built to work across both mobile and desktop.
 
-Rather than a big-bang launch, **we delivered the site in incremental content releases** so families and providers could start benefiting from improvements sooner. This approach also let the team test assumptions, gather feedback, and adjust the design in response to real usage patterns.
+Rather than a big-bang launch, **we delivered the site in incremental content releases** so families and providers could start benefiting from improvements sooner. The approach also let the team test assumptions, gather feedback, and adjust the design in response to real usage patterns.
 
-**To ensure OEC could sustain the site independently,** we equipped internal staff with a content management system, published [content guidelines](https://www.ctoec.org/oec-staff-website-support/style-guide/), and provided hands-on training. This gave the agency the tools and confidence to manage, update, and evolve the site on its own — without relying on outside support for routine changes.
+**To ensure OEC could sustain the site independently,** we equipped internal staff with a content management system, published [content guidelines](https://www.ctoec.org/oec-staff-website-support/style-guide/), and provided hands-on training. The agency gained the tools and confidence to manage, update, and evolve the site on its own — without relying on outside support for routine changes.
 {% endcapture %}
 
 {% capture results %}


### PR DESCRIPTION
## Summary
- Curls apostrophes.
- Splits long sentences to drop approximate Flesch-Kincaid grade from 14.9 to 13.9 and long-sentence warnings from 7 to 2.
- Varies bolded opener shapes per writer skill v0.9.2.

## Test plan
- [x] Schema lint clean
- [x] Core style lint clean
- [x] Word list lint clean
- [x] Grade 14.9 → 13.9
- [x] Local preview renders at `/work/experience/ct-oec-website-redesign/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)