### PR TITLE
Rewrite HHS Telehealth case study + fix news_post title rendering bug

### DIFF
--- a/_includes/project.html
+++ b/_includes/project.html
@@ -112,7 +112,7 @@
       <ul>
         {% for post in page.news_posts %}
         <li>
-          <a href="{{post.url}}">{{post.title | markdownify }}</a>
+          <a href="{{post.url}}">{{post.title}}</a>
         </li>
         {% endfor %}
       </ul>

--- a/_projects/hhs_telehealth_website.md
+++ b/_projects/hhs_telehealth_website.md
@@ -78,7 +78,7 @@ news_posts:
     url: https://digital.gov/2020/10/16/product-lessons-from-the-front-lines-of-covid-19-civic-tech-response/
   - title: "Health Providers: Join the Telehealth Revolution"
     url: https://www.hiv.gov/blog/health-providers-join-telehealth-revolution
-  - title: "COVID-19 | Five Things to Know About Telehealth During the COVID-19 Pandemic"
+  - title: "COVID-19: Five Things to Know About Telehealth During the COVID-19 Pandemic"
     url: https://youtube.com/embed/1gK1dfWUKsA?rel=0
 project_url: https://telehealth.hhs.gov/
 project_cta: "See the site"
@@ -86,27 +86,27 @@ source_code_url:
 ---
 
 {% capture summary %}
-Telehealth.HHS.gov is a plain-language public website that helps healthcare providers and patients understand, access, and use telehealth. We partnered with the Health Resources and Services Administration, teams across the U.S. Department of Health and Human Services (HHS), and the Presidential Innovation Fellows to launch the site during the COVID-19 public health emergency — translating rapidly changing federal guidance into clear, actionable information at national scale.
+Telehealth.HHS.gov is a plain-language public website that helps healthcare providers and patients understand, access, and use telehealth. We partnered with the Health Resources and Services Administration (HRSA), teams across the U.S. Department of Health and Human Services (HHS), and the Presidential Innovation Fellows to launch the site during the COVID-19 public health emergency. The launch translated rapidly changing federal guidance into clear, actionable information at national scale.
 {% endcapture %}
 
 {% capture challenge %}
-COVID-19 placed extraordinary strain on the U.S. healthcare system and made remote care essential almost overnight. New federal policies and temporary flexibilities rapidly expanded telehealth coverage, availability, and eligible use cases — but the information was scattered across agencies, written in regulatory language, and evolving faster than providers or patients could track.
+COVID-19 placed extraordinary strain on the U.S. healthcare system and made remote care essential almost overnight. New federal policies and temporary flexibilities rapidly expanded telehealth coverage, availability, and eligible use cases. But the information was scattered across agencies, written in regulatory language, and evolving faster than providers or patients could track.
 
-More than one million healthcare providers and over 300 million patients across the country needed trustworthy, up-to-date guidance. Providers couldn't easily find out which telehealth services were newly covered, what technology met compliance requirements, or how billing rules had changed. Patients didn't know whether their conditions qualified for virtual visits, how to prepare for one, or where to find low-cost options.
+More than one million healthcare providers and over 300 million patients across the country needed trustworthy, up-to-date guidance. Providers couldn’t easily find out which telehealth services were newly covered, what technology met compliance requirements, or how billing rules had changed. Patients didn’t know whether their conditions qualified for virtual visits, how to prepare for one, or where to find low-cost options.
 
-The challenge was twofold: centralize the most relevant telehealth information from across HHS and deliver it in plain language that people could understand and act on immediately — all on an unusually compressed timeline during a public health emergency.
+The challenge was twofold: centralize the most relevant telehealth information from across HHS and deliver it in plain language people could act on immediately — all on an unusually compressed timeline during a public health emergency.
 {% endcapture %}
 
 {% capture solution %}
-**The timeline demanded emergency speed — less than two weeks from concept to production.** Leaders and subject-matter experts from HHS, HRSA, the Office of Science and Technology Policy, FEMA, and the Assistant Secretary for Preparedness and Response came together to define the vision, and our team designed and built [Telehealth.HHS.gov](https://telehealth.hhs.gov/) to meet that deadline.
+**The timeline demanded emergency speed — less than two weeks from concept to production.** Leaders and subject-matter experts from HHS, HRSA, the Office of Science and Technology Policy, FEMA, and the Assistant Secretary for Preparedness and Response came together to define the vision. Our team designed and built [Telehealth.HHS.gov](https://telehealth.hhs.gov/) to meet that deadline.
 
-Before writing a single line of content, **we talked to the people on the front lines.** Interviews with physicians and members of the public revealed gaps in telehealth awareness, confusion about rapidly changing policies, and uncertainty about how to get started. These conversations shaped the site's content priorities and validated a core hypothesis: providers and patients needed a single, centralized place for plain-language telehealth guidance — not another policy portal.
+Before writing a single line of content, **we talked to the people on the front lines.** Interviews with physicians and members of the public revealed gaps in telehealth awareness, confusion about rapidly changing policies, and uncertainty about how to get started. These conversations shaped the site’s content priorities and validated a core hypothesis: providers and patients needed a single, centralized place for plain-language telehealth guidance — not another policy portal.
 
-**Rapid research cycles validated designs and content before launch.** Moderated and unmoderated usability studies with more than 75 participants tested early prototypes and refined the information architecture, content tone, and navigation. Working closely with subject-matter experts across HHS ensured that the content was both accurate and understandable.
+**Rapid research cycles validated designs and content before launch.** Moderated and unmoderated usability studies with more than 75 participants tested early prototypes and refined the information architecture, content tone, and navigation. Working closely with subject-matter experts across HHS ensured the content was both accurate and understandable.
 
 Proven open-source foundations — the U.S. Web Design System, Jekyll, and GitHub Actions — **let the team move fast without sacrificing quality.** Touchpoints and Google Analytics provided immediate feedback loops so the team could measure usefulness and iterate after launch.
 
-**A content guide developed alongside the product maintained quality at speed.** The guide established plain-language standards, editorial conventions, and review workflows — ensuring that content from multiple contributors stayed consistent and that future content development wouldn't require the original team's direct involvement.
+**A content guide developed alongside the product maintained quality at speed.** The guide established plain-language standards, editorial conventions, and review workflows. Content from multiple contributors stayed consistent, and future content development wouldn’t require the original team’s direct involvement.
 
 **After launch, we expanded the site with high-priority guidance.** New content addressed specialized topics such as telehealth in emergency departments, direct-to-consumer telehealth, and best practices for providers. We added tips for finding free or low-cost telehealth services through health centers, along with guidance on improving telehealth access, equity, and accessibility.
 {% endcapture %}
@@ -114,9 +114,9 @@ Proven open-source foundations — the U.S. Web Design System, Jekyll, and GitHu
 {% capture results %}
 - **Launched Telehealth.HHS.gov from inception to production in less than two weeks** during the peak of the COVID-19 public health emergency
 - **Conducted research with more than 75 participants** — including interviews and unmoderated usability studies — to validate content and design decisions before the initial launch
-- **Achieved a 75% "yes" rate** on the site's "Is this page useful?" feedback survey, indicating that the plain-language approach resonated with users
+- **Achieved a 75% “yes” rate** on the site’s “Is this page useful?” feedback survey, indicating that the plain-language approach resonated with users
 - **Served over one million healthcare providers and 300 million+ patients** as the centralized federal resource for telehealth guidance during the pandemic
-- **Successfully transitioned the site to a larger contractor** for ongoing operation and growth, demonstrating that the product, content standards, and workflows were built to last beyond the original team
+- **Successfully transitioned the site to a larger contractor** for ongoing operation and growth, demonstrating the product, content standards, and workflows were built to last beyond the original team
 {% endcapture %}
 
 {% include project.html


### PR DESCRIPTION
## Summary

**Case study rewrite (hhs_telehealth_website.md)**
- Curls apostrophes and quotes; expands HRSA as "Health Resources and Services Administration (HRSA)" inline.
- Splits long sentences to drop approximate Flesch-Kincaid grade from 15.8 to 14.7.
- Six conceptual-scaffold steps with varied bolded opener shapes per writer skill v0.9.2.

**Template bug fix (_includes/project.html)**

Removes `| markdownify` from the news_post title rendering.

**The bug:** `{{ post.title | markdownify }}` ran every news_post title through kramdown. Kramdown sees `text | text` on a single line as a Markdown table and wraps the title in `<table><tr><td>...</td><td>...</td></tr></table>`. On the HHS Telehealth page, the YouTube news_post title `"COVID-19 | Five Things to Know About Telehealth During the COVID-19 Pandemic"` rendered as a broken two-column table inside the news-coverage list — visible to the user as a wrapped, misaligned link.

**Why removing markdownify is safe:** I audited all 64 case studies. No `news_posts.title` value uses Markdown-active characters (`*`, `_`, `` ` ``, `[`, `|`) except the one fixed in this PR. News post titles are plain text — the filter served no real purpose and only created this bug class.

**Belt-and-suspenders content fix:** also replaced `|` with `:` in the HHS YouTube news_post title, so even if the template fix were ever reverted, this title wouldn't re-trigger the bug.

## Test plan
- [x] Schema lint clean on hhs_telehealth_website.md
- [x] Core style lint clean
- [x] Word list lint clean
- [x] Acronym lint clean
- [x] Grade 15.8 → 14.7
- [x] Local preview verified: all 5 news_post links now render as plain text (no `<table>` wrapper)
- [ ] Spot-check news-coverage rendering on a couple other case studies after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)