### PR TITLE
Remove fabricated pullquote from JIL case study

### DIFF
--- a/_projects/jil_website_redesign.md
+++ b/_projects/jil_website_redesign.md
@@ -76,11 +76,6 @@ Data visualization guidance rounded out the engagement. Clear standards for char
 - **Established a WCAG-compliant brand system** with accessible color palettes, typography, and design patterns that eliminated unintended bias signaling
 - **Created reusable templates and brand guidelines** that enabled non-design staff to independently create and maintain content
 - **Delivered the full redesign in six weeks,** with JIL launching the new experience across its website and brand touchpoints shortly after the engagement concluded
-
-{% include callout.html
-  type = "pullquote"
-  content = "The redesign made it significantly easier to understand and engage with JIL's work."
-%}
 {% endcapture %}
 
 {% include project.html


### PR DESCRIPTION
## Summary

Removes the pullquote `"The redesign made it significantly easier to understand and engage with JIL's work."` from `_projects/jil_website_redesign.md`. The quote had no attribution and didn't appear in the original case-study intake doc (section L "Client quotes" was empty). It was fabricated by an earlier rewrite and carried forward into the recently-merged PR #499.

## Related

- A new linter check, `pullquote_unattributed`, was added in skylight-hub PR #27 (skylight-website-case-study v0.9.3) so this pattern gets surfaced going forward.

## Corpus follow-up

The same linter check flags 10 other case studies on master with unattributed pullquotes. Each one needs reviewer verification — the quote is either a real anonymous research quote (legit, leave as-is) or a fabrication that should be removed. List:

- cdc_dibbs_ecr_viewer
- cdc_simplereport (pullquote #2)
- ct_ece_reporter
- ncoc_refugee_admissions_research (pullquote #2)
- usaf_affms (this one is public USAF policy text, likely legit)
- usaf_logux (pullquote #1)
- usaf_wxpo_bifrost (both pullquotes)
- ussf_web_portal

Not addressed in this PR — needs source-doc verification per case study.

## Test plan
- [x] Schema lint clean
- [x] `pullquote_unattributed` no longer fires on jil_website_redesign.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)