### PR TITLE
Rewrite ACME DevOps transformation case study using website-case-study-writer skill

### DIFF
--- a/_projects/acme_devops_transformation.md
+++ b/_projects/acme_devops_transformation.md
@@ -57,28 +57,28 @@ We helped a $1B+ enterprise design and stand up a DevOps operating model — anc
 {% endcapture %}
 
 {% capture challenge %}
-ACME manages a technology organization of more than 400 people supporting a $1B+ business. Leadership understood the potential of modern DevOps practices — faster delivery, higher quality, better customer outcomes — but earlier efforts to adopt them had produced limited results.
+ACME manages a technology organization of more than 400 people supporting a $1B+ business. Leadership understood the potential of modern DevOps practices — faster delivery, higher quality, better customer outcomes. But earlier efforts to adopt them had produced limited results.
 
-The problem wasn't awareness. Initial DevOps initiatives lacked the structure, leadership alignment, and talent strategy needed to take hold across an organization of that size. Without a clear operating model, adoption was uneven. Teams experimented in isolation, gains didn't compound, and confidence in DevOps as a strategy eroded.
+The problem wasn’t awareness. Initial DevOps initiatives lacked the structure, leadership alignment, and talent strategy needed to take hold across an organization of that size. Without a clear operating model, adoption was uneven. Teams experimented in isolation, gains didn’t compound, and confidence in DevOps as a strategy eroded.
 
 By the time Skylight engaged, the organization needed more than a second attempt at tooling and process change. It needed a fundamentally different approach — one that treated DevOps not as a set of tools to adopt but as an operating model to build, staff, and sustain.
 {% endcapture %}
 
 {% capture solution %}
-We designed our approach around a core premise: **DevOps wouldn't stick unless ACME owned it.** Every decision we made — from how we structured the assessment to how we staffed the Center of Excellence — was aimed at building internal capability, not creating a dependency on external consultants.
+We designed our approach around a core premise: **DevOps wouldn’t stick unless ACME owned it.** Every decision we made — from how we structured the assessment to how we staffed the Center of Excellence — was aimed at building internal capability, not creating a dependency on external consultants.
 
-The first step was understanding where ACME actually stood. **Using [DevOps Research and Assessment (DORA)](/thoughts/blog/achieve-devops-transformation-with-skylight-and-dora/), we established an empirical baseline** — benchmarking the organization's software delivery performance against industry data to identify the highest-leverage gaps. DORA's research-backed framework gave leadership something previous initiatives had lacked: a shared, data-driven picture of what needed to change and why, grounded in how ACME compared to its peers rather than in opinions or best-practice checklists.
+The first step was understanding where ACME actually stood. **Using [DevOps Research and Assessment (DORA)](/thoughts/blog/achieve-devops-transformation-with-skylight-and-dora/), we established an empirical baseline.** We benchmarked the organization’s software delivery performance against industry data to identify the highest-leverage gaps. DORA’s research-backed framework gave leadership something previous initiatives had lacked: a shared, data-driven picture of what needed to change and why, grounded in how ACME compared to its peers rather than in opinions or best-practice checklists.
 
 ![Infographic outlining how the DORA assessment methodology works.](/img/blog/dora/dora-infographic.svg){: .mb-0 }
 
 DORA assessment methodology.
 {: .caption }
 
-Those benchmarked gaps became the blueprint for what came next. **We designed a DevOps operating model centered on a dedicated Center of Excellence (CoE)** — not as an abstract strategy document, but as a staffed, funded organization with clear priorities. We partnered with leadership to align around the improvements that would move the needle most, defined the talent model needed to staff the CoE, and created a transformation roadmap that sequenced investments for maximum impact.
+Those benchmarked gaps became the blueprint for what came next. **We designed a DevOps operating model centered on a dedicated Center of Excellence (CoE).** Not an abstract strategy document — a staffed, funded organization with clear priorities. We partnered with leadership to align around the improvements that would move the needle most, defined the talent model needed to staff the CoE, and created a transformation roadmap that sequenced investments for maximum impact.
 
-Standing up the operating model required getting the right people in place quickly. We supported recruiting, interviewing, and onboarding for the CoE — including its leadership — and **delivered hands-on coaching and training to accelerate capability development.** Periodic health checks kept the transformation on track, surfacing what was working and what needed course correction before small problems became systemic ones.
+Standing up the operating model required getting the right people in place quickly. We supported recruiting, interviewing, and onboarding for the CoE — including its leadership. **Hands-on coaching and training accelerated capability development.** Periodic health checks kept the transformation on track, surfacing what was working and what needed course correction before small problems became systemic ones.
 
-The goal was never to run ACME's DevOps transformation for them. **By the end of the engagement, we'd transitioned full ownership to the CoE itself** — a team that had grown from its initial group of specialists into a broader digital capability organization driving change across the enterprise.
+The goal was never to run ACME’s DevOps transformation for them. **By the end of the engagement, we had transitioned full ownership to the CoE itself** — a team that had grown from its initial group of specialists into a broader digital capability organization driving change across the enterprise.
 {% endcapture %}
 
 {% capture results %}


### PR DESCRIPTION
## Summary
- Curls apostrophes throughout.
- Splits long sentences to drop approximate Flesch-Kincaid grade from 15.2 to 13.8.
- Five solution bolds with varied opener shapes per writer skill v0.9.2.

## Test plan
- [x] Schema lint clean
- [x] Core style lint clean
- [x] Word list lint clean
- [x] Grade 15.2 → 13.8
- [x] Local preview renders at `/work/experience/acme-devops-transformation/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)