### PR TITLE
Rewrite UN accessibility case study using website-case-study-writer skill

### DIFF
--- a/_projects/united_nations_accessibility.md
+++ b/_projects/united_nations_accessibility.md
@@ -35,32 +35,32 @@ source_code_url:
 ---
 
 {% capture summary %}
-The United Nations (UN) 2019 Global Platform for Disaster Risk Reduction conference website didn't meet Web Content Accessibility Guidelines (WCAG) 2.0 standards, leaving visitors with disabilities unable to fully access event information. We audited the site, fixed the underlying code, and validated the results with persons with disabilities — all within two weeks before the conference opened.
+The United Nations (UN) 2019 Global Platform for Disaster Risk Reduction conference website didn’t meet Web Content Accessibility Guidelines (WCAG) 2.0 standards, leaving visitors with disabilities unable to fully access event information. We audited the site, fixed the underlying code, and validated the results with persons with disabilities — all within two weeks before the conference opened.
 {% endcapture %}
 
 {% capture challenge %}
-The Global Platform for Disaster Risk Reduction is the UN's flagship event for coordinating international efforts to reduce disaster risk, drawing thousands of delegates from governments, international organizations, and civil society. The 2019 conference website served as the primary channel for attendees to find schedules, register, and access event materials — but it didn't meet WCAG 2.0 accessibility standards.
+The Global Platform for Disaster Risk Reduction is the UN’s flagship event for coordinating international efforts to reduce disaster risk. The conference draws thousands of delegates from governments, international organizations, and civil society. The 2019 conference website served as the primary channel for attendees to find schedules, register, and access event materials. But it didn’t meet WCAG 2.0 accessibility standards.
 
-The gaps spanned multiple areas: images lacked proper alternative text, color contrast ratios fell below minimum thresholds, interactive elements were missing keyboard-accessible outlines, and navigation structures didn't support screen readers. For attendees who relied on assistive technology, the site was effectively unusable for key tasks.
+The gaps spanned multiple areas. Images lacked proper alternative text. Color contrast ratios fell below minimum thresholds. Interactive elements were missing keyboard-accessible outlines. Navigation structures didn’t support screen readers. For attendees who relied on assistive technology, the site was effectively unusable for key tasks.
 
-With the conference just weeks away, the UN Office for Disaster Risk Reduction's technology team needed to both identify every accessibility deficiency and fix it — fast enough to meet the event deadline without disrupting the live site.
+With the conference just weeks away, the UN Office for Disaster Risk Reduction’s technology team needed to both identify every accessibility deficiency and fix it — fast enough to meet the event deadline without disrupting the live site.
 {% endcapture %}
 
 {% capture solution %}
-Using [Skylight's Accessibility Guide](/work/toolkits/accessibility-guide/) as the framework, we opened with a comprehensive audit that systematically evaluated images, color contrast ratios, keyboard navigation, outlines, and other content against WCAG 2.0 criteria. Every deficiency went into a **prioritized report** so the UN's technology team could see the full scope of work ahead.
+**The two-week deadline forced a different approach: fix the live site, don't stage changes.** Using [Skylight’s Accessibility Guide](/work/toolkits/accessibility-guide/) as the framework, we opened with a comprehensive audit that systematically evaluated images, color contrast ratios, keyboard navigation, outlines, and other content against WCAG 2.0 criteria. Every deficiency went into a prioritized report so the UN’s technology team could see the full scope of work ahead.
 
-**Fixes happened directly in the live codebase** — there was no time to stage changes for a future release. We rewrote the underlying HTML and JavaScript to add proper alternative text to images, correct contrast ratios, restore keyboard-accessible outlines, and restructure navigation elements for screen reader compatibility. Working on the live site meant compliance would be in place before the first attendees arrived.
+**Fixes happened directly in the live codebase.** We rewrote the underlying HTML and JavaScript to add proper alternative text to images, correct contrast ratios, restore keyboard-accessible outlines, and restructure navigation elements for screen reader compatibility. Compliance had to be in place before the first attendees arrived.
 
-Automated checks alone couldn't confirm real usability. We validated the fixes by **testing with persons with disabilities** who use screen readers and keyboard-only navigation, confirming that the technical changes translated into genuine accessibility improvements.
+**Automated checks alone couldn’t confirm real usability.** We validated the fixes by testing with persons with disabilities who use screen readers and keyboard-only navigation, confirming the technical changes translated into genuine accessibility improvements.
 
-The engagement's final deliverable looked beyond the conference itself. We provided **accessibility development guidelines** that gave the UN's technology team a reference for maintaining WCAG 2.0 compliance on future conference sites without outside support.
+The engagement’s final deliverable looked beyond the conference itself. **Accessibility development guidelines gave the UN’s technology team a reference for maintaining WCAG 2.0 compliance on future conference sites** without outside support.
 {% endcapture %}
 
 {% capture results %}
 - **Completed the full accessibility audit and remediation in two weeks**, meeting the conference deadline for the 2019 Global Platform for Disaster Risk Reduction
 - **Achieved WCAG 2.0 compliance** across the conference website, covering images, color contrast, keyboard navigation, and screen reader support
-- **Validated fixes through usability testing with persons with disabilities**, confirming that technical changes produced real accessibility gains
-- **Delivered accessibility development guidelines** enabling the UN's technology team to maintain compliance independently on future conference sites
+- **Validated fixes through usability testing with persons with disabilities**, confirming the technical changes produced real accessibility gains
+- **Delivered accessibility development guidelines** enabling the UN’s technology team to maintain compliance independently on future conference sites
 {% endcapture %}
 
 {% include project.html


### PR DESCRIPTION
## Summary
- Curls apostrophes throughout.
- Splits long sentences to drop approximate Flesch-Kincaid grade from 15.2 to 13.8.
- Four solution bolds carrying strategic insight per writer skill v0.9.2: the two-week deadline forced live-site fixes, fixes happened in the live codebase, automated checks alone couldn't confirm real usability, and guidelines as the handoff.

## Test plan
- [x] Schema lint clean
- [x] Core style lint clean
- [x] Word list lint clean
- [x] Grade 15.2 → 13.8
- [x] Local preview renders at `/work/experience/united-nations-accessibility-support/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)