### PR TITLE
Rewrite TSA cloud adoption case study using website-case-study-writer skill

### DIFF
--- a/_projects/tsa_cloud_adoption.md
+++ b/_projects/tsa_cloud_adoption.md
@@ -20,7 +20,7 @@ tags:
   - "homeland security"
   - "chris cairns"
   - "shashank khandelwal"
-excerpt: "Before strarting Skylight, Chris Cairns and Shashank Khandelwal helped the Transportation Security Administration accelerate its transition to a cloud-based operating model."
+excerpt: "Before starting Skylight, Chris Cairns and Shashank Khandelwal helped the Transportation Security Administration accelerate its transition to a cloud-based operating model."
 project_members:
   - chris-cairns
   - shashank-khandelwal
@@ -49,29 +49,29 @@ source_code_url:
 ---
 
 {% capture summary %}
-Before starting Skylight, Chris Cairns and Shashank Khandelwal led an initiative at 18F to jumpstart the Transportation Security Administration's (TSA's) adoption of a cloud-based operating model. By pairing TSA with a specialized team of site reliability engineers, they helped the agency chart a practical path from costly on-premise infrastructure to modern cloud operations.
+Before starting Skylight, Chris Cairns and Shashank Khandelwal led an initiative at 18F to jumpstart the Transportation Security Administration’s (TSA’s) adoption of a cloud-based operating model. By pairing TSA with a specialized team of site reliability engineers, they helped the agency chart a practical path from costly on-premise infrastructure to modern cloud operations.
 {% endcapture %}
 
 {% capture challenge %}
-TSA's Chief Information Officer organization was spending heavily to maintain on-premise IT infrastructure, and imminent budget cuts threatened to make those costs unsustainable. The cloud offered a way forward — lower operating expenses, greater scalability, and a foundation for modern development practices — but the organization lacked the hands-on experience needed to make the transition.
+TSA’s Chief Information Officer organization was spending heavily to maintain on-premise IT infrastructure. Imminent budget cuts threatened to make those costs unsustainable. The cloud offered a way forward — lower operating expenses, greater scalability, and a foundation for modern development practices. But the organization lacked the hands-on experience needed to make the transition.
 
-The gap wasn't just technical. TSA's existing teams didn't have deep expertise in cloud architecture, automated deployment pipelines, or the DevOps practices required to operate reliably in a cloud environment. Without that knowledge, a large-scale migration risked becoming another costly initiative that stalled before delivering results. The agency needed a strategy that would build internal capability while demonstrating early wins fast enough to justify the investment.
+The gap wasn’t just technical. TSA’s existing teams didn’t have deep expertise in cloud architecture, automated deployment pipelines, or the DevOps practices required to operate reliably in a cloud environment. Without that knowledge, a large-scale migration risked becoming another costly initiative that stalled before delivering results. The agency needed a strategy that would build internal capability while demonstrating early wins fast enough to justify the investment.
 {% endcapture %}
 
 {% capture solution %}
-A wholesale migration would have replicated the same big-bang risk that plagued waterfall software projects — what Chris Cairns and Shashank Khandelwal called "cloudfall." As members of 18F, they designed a phased approach instead, pairing TSA with an expert team of site reliability engineers to build momentum through manageable, iterative steps.
+**A wholesale migration would have replicated the same big-bang risk that plagued waterfall software projects — what Chris and Shashank called “cloudfall.”** As members of 18F, they designed a phased approach instead, pairing TSA with an expert team of site reliability engineers to build momentum through manageable, iterative steps.
 
 **The first move was migrating two low-risk applications within a few months.** These early migrations gave leadership immediate, concrete insight into the organizational changes the shift would require — spanning structure, culture, talent, practices, tooling, and vendor relationships. Starting small reduced risk while producing tangible evidence that the cloud model could work for TSA.
 
-Each migration also served as a proving ground for **DevSecOps practices that TSA hadn't used before.** Infrastructure as code, continuous integration, and automated security controls demonstrated how cloud-native approaches could improve both speed and reliability. These weren't abstract concepts — they were working patterns the team applied to real TSA applications.
+**Each migration also served as a proving ground for DevSecOps practices TSA hadn’t used before.** Infrastructure as code, continuous integration, and automated security controls demonstrated how cloud-native approaches could improve both speed and reliability. These weren’t abstract concepts — they were working patterns the team applied to real TSA applications.
 
-The engagement's lasting value came from what it left behind. Through hands-on training, coaching, and hiring support, Cairns and Khandelwal ensured the agency wouldn't remain dependent on outside expertise. The goal was a **self-sustaining cloud operation**, not a one-time migration.
+The engagement’s lasting value came from what it left behind. **Through hands-on training, coaching, and hiring support, the goal was a self-sustaining cloud operation — not a one-time migration.** The agency wouldn’t remain dependent on outside expertise.
 {% endcapture %}
 
 {% capture results %}
 - **Projected savings of tens of millions of dollars** by transitioning away from on-premise infrastructure, helping TSA address impending budget reductions
 - **Migrated two applications to the cloud within a few months,** providing leadership with a working proof of concept and a clear picture of the organizational changes required for broader adoption
-- **Established a phased, agile migration strategy** for TSA's application portfolio, replacing the risk of a "big bang" migration with an iterative approach that built confidence at each step
+- **Established a phased, agile migration strategy** for TSA’s application portfolio, replacing the risk of a “big bang” migration with an iterative approach that built confidence at each step
 - **Introduced DevSecOps practices** — including infrastructure as code, continuous integration, and automated security controls — that modernized how TSA built and operated applications
 - **Built internal cloud and DevOps competencies** through training, coaching, and civic recruiting, positioning TSA to sustain the transformation independently
 {% endcapture %}


### PR DESCRIPTION
## Summary
- Fixes pre-existing typo `"strarting"` → `"starting"` in the excerpt.
- Curls apostrophes and quotes.
- Splits long sentences to drop approximate Flesch-Kincaid grade from 15.8 to 14.8.
- Four solution bolds carrying strategic insight: "cloudfall" as the big-bang trap, start with two low-risk apps, migrations as DevSecOps proving ground, self-sustaining operation as the real goal.

## Test plan
- [x] Schema lint clean
- [x] Core style lint clean
- [x] Word list lint clean
- [x] Grade 15.8 → 14.8
- [x] Local preview renders at `/work/experience/tsa-cloud-adoption/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)