### PR TITLE
Rewrite CA HHS agile training case study using website-case-study-writer skill

### DIFF
--- a/_projects/ca_hhs_agile_training.md
+++ b/_projects/ca_hhs_agile_training.md
@@ -42,7 +42,7 @@ source_code_url:
 ---
 
 {% capture summary %}
-The California Health and Human Services (CHHS) Office of Innovation understood the individual elements of agile but couldn't connect them into a working delivery approach. We designed and delivered an immersive, two-day training workshop — in partnership with CivicActions — that simulated five full sprints against a real product, helping teams experience agile as a complete system rather than a set of isolated practices.
+The California Health and Human Services (CHHS) Office of Innovation understood the individual elements of agile but couldn’t connect them into a working delivery approach. We designed and delivered an immersive, two-day training workshop in partnership with CivicActions. The workshop simulated five full sprints against a real product, helping teams experience agile as a complete system rather than a set of isolated practices.
 {% endcapture %}
 
 {% capture challenge %}
@@ -55,21 +55,21 @@ The CHHS Office of Innovation had invested in agile training, and the team under
   cite_title = "Deputy Director, Office of Innovation at CHHS"
 %}
 
-The gap wasn't knowledge — it was experience. Without having worked through a full delivery cycle using agile practices end to end, teams struggled to apply what they'd learned to real projects. Previous trainings had taught concepts in isolation, but none had shown how planning, estimation, velocity tracking, and testing reinforce each other as a system. The Office of Innovation needed something fundamentally different: not another lecture, but a way to practice agile as it actually works.
+The gap wasn’t knowledge — it was experience. Without having worked through a full delivery cycle using agile practices end to end, teams struggled to apply what they’d learned to real projects. Previous trainings had taught concepts in isolation, but none had shown how planning, estimation, velocity tracking, and testing reinforce each other as a system. The Office of Innovation needed something fundamentally different: not another lecture, but a way to practice agile as it actually works.
 {% endcapture %}
 
 {% capture solution %}
 The team had learned the individual practices, but no previous training had asked them to use those practices together in a real delivery cycle. **We partnered with [CivicActions](https://civicactions.com/) to design something different:** a full delivery simulation against a real product, where every practice reinforced the others inside a working sprint cycle.
 
-**Over two days, participants worked through five compressed sprints** — not on a hypothetical exercise, but on the Office of Innovation's actual website. Each sprint cycled through the complete Scrum workflow: story writing, estimation, planning, building, testing, and velocity tracking. By the third sprint, teams weren't just following instructions — they were making their own tradeoffs, adjusting estimates based on real velocity data, and experiencing the feedback loops that make agile work.
+Over two days, participants worked through five compressed sprints — not on a hypothetical exercise, but on the Office of Innovation’s actual website. Each sprint cycled through the complete Scrum workflow: story writing, estimation, planning, building, testing, and velocity tracking. **By the third sprint, teams weren’t just following instructions — they were making their own tradeoffs, adjusting estimates based on real velocity data, and experiencing the feedback loops that make agile work.**
 
-That structure was deliberate. Estimation became meaningful once teams could compare predictions against actual velocity. Testing felt purposeful once it was connected to a real user experience. And planning improved naturally as teams built intuition for what they could deliver in a sprint — something no classroom lecture can teach. The workshop worked because **each practice only made sense in the context of the others,** which is exactly how agile works in real delivery.
+That structure was deliberate. **Each practice only made sense in the context of the others, which is exactly how agile works in real delivery.** Estimation became meaningful once teams could compare predictions against actual velocity. Testing felt purposeful once it was connected to a real user experience. Planning improved naturally as teams built intuition for what they could deliver in a sprint — something no classroom lecture can teach.
 
-By the end of the second day, the training had produced something most workshops never do: **a tangible product improvement.** Participants shipped a redesigned version of the Office of Innovation's website — proof that the learning had already translated into real delivery.
+**By the end of the second day, the training had produced something most workshops never do: a tangible product improvement.** Participants shipped a redesigned version of the Office of Innovation’s website. Proof that the learning had already translated into real delivery.
 {% endcapture %}
 
 {% capture results %}
-- **Delivered a redesigned version** of the Office of Innovation's website through hands-on sprint work over two days
+- **Delivered a redesigned version** of the Office of Innovation’s website through hands-on sprint work over two days
 - **Simulated five full sprints** covering the complete Scrum workflow — from story writing through testing and velocity tracking
 - **Equipped teams** to adapt agile practices to fit their own projects and departmental culture
 - **Rated as the most valuable and practical agile training** participants had experienced


### PR DESCRIPTION
## Summary
- Curls apostrophes throughout.
- Splits long sentences to drop approximate Flesch-Kincaid grade from 13.8 to 13.0.
- Four solution bolds carrying strategic insight: delivery simulation as the differentiator, the third-sprint turning point where teams stopped following instructions, holistic practice context, tangible product improvement as the deliverable.

## Test plan
- [x] Schema lint clean
- [x] Core style lint clean
- [x] Word list lint clean
- [x] Grade 13.8 → 13.0
- [x] Local preview renders at `/work/experience/ca-hhs-agile-training/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)