### PR TITLE
Rewrite Navy protosketching case study using website-case-study-writer skill

### DIFF
--- a/_projects/us_navy_protosketching.md
+++ b/_projects/us_navy_protosketching.md
@@ -52,24 +52,24 @@ Before founding Skylight, Robert Read and Tom Black used a technique they pionee
 {% endcapture %}
 
 {% capture challenge %}
-The Navy Reserve needed to modernize how sailors wrote and managed orders for their reserve duties. The existing process wasn't accessible on mobile devices — a significant gap for personnel who needed to handle duty-related tasks outside of a desktop environment. Making mobile access available was a clear priority, but the path forward wasn't obvious.
+The Navy Reserve needed to modernize how sailors wrote and managed orders for their reserve duties. The existing process wasn’t accessible on mobile devices — a significant gap for personnel who needed to handle duty-related tasks outside of a desktop environment. Making mobile access available was a clear priority, but the path forward wasn’t obvious.
 
-The core question was whether to invest in native mobile applications or adopt responsive web design. Each approach carried different cost, maintenance, and timeline implications, and getting the answer wrong would mean months of misallocated development effort. In a traditional procurement environment, answering that kind of question typically required a lengthy requirements-writing phase and contractor engagement before any working software materialized — a timeline that didn't match the urgency of the Reserve's need.
+The core question was whether to invest in native mobile applications or adopt responsive web design. Each approach carried different cost, maintenance, and timeline implications. Getting the answer wrong would mean months of misallocated development effort. In a traditional procurement environment, answering that kind of question typically required a lengthy requirements-writing phase and contractor engagement before any working software materialized — a timeline that didn’t match the urgency of the Reserve’s need.
 {% endcapture %}
 
 {% capture solution %}
-Rather than debating the mobile strategy in the abstract, Robert Read and Tom Black set out to answer it with working software. They applied a technique they'd pioneered at 18F called protosketching — building a **clickable prototype in three hours or less** so that real design and technology decisions could be grounded in something tangible.
+**Rather than debating the mobile strategy in the abstract, Robert and Tom set out to answer it with working software.** They applied a technique they’d pioneered at 18F called protosketching: build a clickable prototype in three hours or less, so real design and technology decisions could be grounded in something tangible.
 
-**The afternoon was structured as three one-hour sprints.** In each sprint, the team wrote user stories that captured the Reserve's core mobile requirements, and developers immediately translated those stories into a functional mock-up. Using HTML, CSS, JavaScript, and Twitter Bootstrap for responsive layout, they created a mobile website that simulated the key functionality R2S needed — viewable on phones and laptops alike.
+**The afternoon was structured as three one-hour sprints.** Each sprint, the team wrote user stories that captured the Reserve’s core mobile requirements. Developers immediately translated those stories into a functional mock-up. Using HTML, CSS, JavaScript, and Twitter Bootstrap for responsive layout, they created a mobile website that simulated the key functionality R2S needed — viewable on phones and laptops alike.
 
-Bootstrap's responsive framework rendered the mock-up cleanly on both mobile devices and a projector, giving the R2S team something no requirements document could: a **firsthand look at the user experience** they were deciding on. The session demonstrated that responsive web design could meet the Reserve's mobile requirements without the overhead of building and maintaining separate native applications. This informed the mobile product strategy for what eventually became the Ready-2-Serve platform — the Navy Reserve's first operational Bring Your Own Device program in the Department of Defense.
+**Bootstrap’s responsive framework rendered the mock-up cleanly on both mobile and projector — giving the R2S team something no requirements document could.** A firsthand look at the user experience they were deciding on. The session demonstrated that responsive web design could meet the Reserve’s mobile requirements without the overhead of building and maintaining separate native applications. The decision informed the mobile product strategy for what eventually became the Ready-2-Serve platform — the Navy Reserve’s first operational Bring Your Own Device program in the Department of Defense.
 {% endcapture %}
 
 {% capture results %}
 - **De-risked a major platform decision in a single afternoon** — the R2S team chose a mobile strategy backed by a working prototype rather than theoretical analysis
-- **Demonstrated responsive web design as a viable path** for the Navy Reserve's mobile needs, avoiding the cost and complexity of native app development
-- **Produced a functional mock-up in three hours** using three one-hour sprints, showing that meaningful technical exploration doesn't require a lengthy procurement cycle
-- **Informed the mobile strategy for Ready-2-Serve**, which launched as the Navy Reserve's first Bring Your Own Device program in the Department of Defense
+- **Demonstrated responsive web design as a viable path** for the Navy Reserve’s mobile needs, avoiding the cost and complexity of native app development
+- **Produced a functional mock-up in three hours** using three one-hour sprints, showing that meaningful technical exploration doesn’t require a lengthy procurement cycle
+- **Informed the mobile strategy for Ready-2-Serve**, which launched as the Navy Reserve’s first Bring Your Own Device program in the Department of Defense
 {% endcapture %}
 
 {% include project.html


### PR DESCRIPTION
## Summary
- Curls apostrophes throughout.
- Splits long sentences to drop approximate Flesch-Kincaid grade from 16.7 to 14.9.
- Three solution bolds carrying strategic insight: answer the strategy question with working software, structure as three one-hour sprints, prototype-vs-document framing.

## Test plan
- [x] Schema lint clean
- [x] Core style lint clean
- [x] Word list lint clean
- [x] Grade 16.7 → 14.9
- [x] Local preview renders at `/work/experience/us-navy-protosketching/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)