### PR TITLE
Enable overlay plugins + adopt channel-writers split (PR SD-2)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,15 @@
     "content-style-linters@skylight-hub": true,
     "skylight-respectful-language@skylight-hub": true,
     "skylight-voice-and-tone@skylight-hub": true,
-    "skylight-channel-writers@skylight-hub": true
+    "skylight-blog-writer@skylight-hub": true,
+    "skylight-microcopy-writer@skylight-hub": true,
+    "skylight-alt-text-writer@skylight-hub": true,
+    "skylight-spotlight-writer@skylight-hub": true,
+    "skylight-blog-content-overlay@skylight-hub": true,
+    "skylight-microcopy-content-overlay@skylight-hub": true,
+    "skylight-alt-text-content-overlay@skylight-hub": true,
+    "skylight-proposal-content-overlay@skylight-hub": true,
+    "skylight-case-study-content-overlay@skylight-hub": true,
+    "skylight-spotlight-content-overlay@skylight-hub": true
   }
 }


### PR DESCRIPTION
## Summary

Per [`skylight-hub/proposals/active/skylight-digital-followups.md`](https://github.com/skylight-hq/skylight-hub/blob/main/proposals/active/skylight-digital-followups.md) **PR SD-2**.

Enables the 6 content-overlay plugins and the 4 per-channel writer plugins (which replace the deprecated `skylight-channel-writers` bundle) in this site's Claude Code workspace.

## What changed

Single file: `.claude/settings.json` — `enabledPlugins` map.

**Added (10 entries):**

| Category | Plugins |
|---|---|
| Per-channel writers | `skylight-blog-writer`, `skylight-microcopy-writer`, `skylight-alt-text-writer`, `skylight-spotlight-writer` |
| Content overlays | `skylight-blog-content-overlay`, `skylight-microcopy-content-overlay`, `skylight-alt-text-content-overlay`, `skylight-proposal-content-overlay`, `skylight-case-study-content-overlay`, `skylight-spotlight-content-overlay` |

**Removed:** `skylight-channel-writers` (deprecated stub).

## Why this matters

Writer skills now load supporting material from sibling overlay plugins via `${CLAUDE_PLUGIN_ROOT}/../<overlay-name>/content/...`. For those chaining paths to resolve at install time, both the writer and the overlay plugins need to be enabled in this workspace.

The chaining works because Claude Code installs all enabled plugins side-by-side in the same plugin root, so `${CLAUDE_PLUGIN_ROOT}/../<overlay-name>/` resolves to the sibling overlay's installed directory.

## Test plan

After merge:

- [ ] Restart Claude Code in this workspace to pick up new plugins
- [ ] `blog-post-writer` — draft a blog post; verify `skylight-blog-content-overlay/content/templates.md` resolves
- [ ] `microcopy-writer` — write microcopy for a button; verify `skylight-microcopy-content-overlay/content/patterns.md` resolves
- [ ] `alt-text-writer` — write alt text; verify `skylight-alt-text-content-overlay/content/patterns.md` resolves
- [ ] `website-case-study-writer` — review a case study draft; verify `skylight-case-study-content-overlay/content/{clients,frontmatter,style,...}.md` resolves
- [ ] `employee-spotlight-writer` — draft a spotlight; placeholder overlay (empty content/) should not error

## Rollback

If chaining breaks, revert the PR. Writer skills' core behavior (chaining linters + reviewers) is preserved either way; only the overlay material loads break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)