### PR TITLE
Add canonical case-study taxonomies (technologies.yml + practices.yml)

### DIFF
--- a/_data/_taxonomy_migration_notes.md
+++ b/_data/_taxonomy_migration_notes.md
@@ -1,0 +1,269 @@
+# Case-study taxonomy migration — notes + sample mappings
+
+This file accompanies the new `_data/technologies.yml` and `_data/practices.yml` canonical lists. It documents:
+
+1. **Three sample case-study migrations** showing how existing free-text frontmatter maps to canonical values.
+2. **General mapping rules** that apply to the full 64-case-study migration.
+3. **Known ambiguities** that need editorial review.
+
+The full per-case-study migration is tracked in [`skylight-hub/migrations/case-study-taxonomy-rationalization.md`](https://github.com/skylight-hq/skylight-hub/blob/main/migrations/case-study-taxonomy-rationalization.md).
+
+## General rules
+
+| Rule | Example |
+|---|---|
+| Composite → atomic | `"JavaScript / React / TypeScript"` → 3 entries: `JavaScript`, `React`, `TypeScript` |
+| Vendor noise → canonical | `"AWS (Cloud One)"` → `Amazon Web Services` (drop the Cloud One parenthetical) |
+| Drop non-answers | `"Existing technology stack"`, `"Apple"`, `"Custom spidering script"` → remove |
+| Drop dead products | `"appear.in"` → remove (product shut down) |
+| Drop HR tooling unless HR-relevant | `"Lever (recruiting software)"`, `"Workable (recruiting software)"` → remove unless the case study is specifically about recruiting |
+| Consolidate near-duplicates via aliases | `"Accessibility"` / `"Accessibility design"` / `"Accessibility review"` / `"Accessible design"` → `Accessibility design` (canonical) |
+| Move person names out of tags | `tags: [..., "chris cairns", ...]` → `project_members:` field (already exists; tag is duplicate) |
+| Drop person names already in project_members | If "chris-cairns" is in `project_members:`, "chris cairns" gets dropped from `tags:` |
+| Tags should be topic-only | After migration, `tags:` contains capability / mission / topic — no person names |
+
+## Sample 1 — `_projects/18f_consulting.md`
+
+Most problematic case study: ancient, full of person names in tags, "Apple" as a tech, dead products.
+
+**Before:**
+
+```yaml
+tags:
+  - "transformation"
+  - "chris cairns"
+  - "robert read"
+technologies:
+  - "Lever (recruiting software)"
+  - "Google Workspace"
+  - "Trello"
+  - "Slack"
+  - "Mural"
+  - "appear.in"
+  - "cloud.gov / Amazon Web Services"
+  - "Federalist / GitHub Pages"
+  - "Jekyll"
+  - "Git / GitHub"
+  - "Apple"
+practices:
+  - "Servant leadership"
+  - "Team of teams"
+  - "Management by objectives"
+  - "Schedule A(r) hiring authority"
+  - "Civic recruiting"
+  - "Performance profiles"
+  - "Google interview practices"
+  - "Open innovation"
+  - "Virtual collaboration"
+  - "Knowledge management"
+  - "Peer mentoring and coaching"
+  - "Continuous improvement"
+```
+
+**After:**
+
+```yaml
+tags:
+  - "transformation"
+technologies:
+  - "Google Workspace"
+  - "Trello"
+  - "Slack"
+  - "Mural"
+  - "cloud.gov"
+  - "Amazon Web Services"
+  - "GitHub Pages"
+  - "Jekyll"
+  - "Git"
+  - "GitHub"
+practices:
+  - "Servant leadership"
+  - "Team of teams"
+  - "Management by objectives"
+  - "Schedule A(r) hiring authority"
+  - "Civic recruiting"
+  - "Performance management"
+  - "Open-source development"
+  - "Virtual collaboration"
+  - "Knowledge management"
+  - "Coaching and training"
+  - "Continuous improvement"
+```
+
+**Decisions:**
+
+- Dropped person-name tags (already in `project_members:`).
+- Dropped `"Lever (recruiting software)"` — HR tooling, not engagement tech.
+- Dropped `"appear.in"` — dead product.
+- Dropped `"Apple"` — not a technology.
+- Split `"cloud.gov / Amazon Web Services"` into both clouds.
+- Split `"Federalist / GitHub Pages"` into both. (Federalist was rebranded; canonical is `GitHub Pages`.)
+- Split `"Git / GitHub"` into Git + GitHub.
+- Mapped `"Performance profiles"` → `Performance management` (closest canonical).
+- Mapped `"Google interview practices"` → dropped (too vague + Google-specific).
+- Mapped `"Open innovation"` → `Open-source development` (the canonical's aliases include this).
+- Mapped `"Peer mentoring and coaching"` → `Coaching and training` (consolidated alias).
+
+## Sample 2 — `_projects/cdc_simplereport.md`
+
+Modern engagement, mostly clean composites.
+
+**Before (excerpt):**
+
+```yaml
+technologies:
+  - "HTML / CSS"
+  - "Storybook"
+  - "Chromatic"
+  - "U.S. Web Design System"
+  - "Figma"
+  - "Mural"
+  - "Respondent"
+  - "React in TypeScript with Apollo"
+  - "Nightwatch"
+  - "Cypress"
+  - "Lighthouse"
+  - "Java / Spring Boot"
+  - "GraphQL"
+  - "Liquibase"
+  - "SmartyStreets"
+  - "PostgreSQL"
+  - "Terraform"
+  - "Microsoft Azure"
+  - "Docker"
+  - "Okta"
+  - "Experian"
+  - "Twilio"
+  - "SendGrid"
+  - "Git / GitHub"
+  - "ZenHub"
+  - "SonarCloud"
+  - "Dependabot"
+  - "Snyk"
+```
+
+**After (excerpt):**
+
+```yaml
+technologies:
+  - "HTML"
+  - "CSS"
+  - "Storybook"
+  - "Chromatic"
+  - "U.S. Web Design System"
+  - "Figma"
+  - "Mural"
+  - "React"
+  - "TypeScript"
+  - "Apollo"
+  - "Nightwatch"
+  - "Cypress"
+  - "Lighthouse"
+  - "Java"
+  - "Spring Boot"
+  - "GraphQL"
+  - "Liquibase"
+  - "PostgreSQL"
+  - "Terraform"
+  - "Microsoft Azure"
+  - "Docker"
+  - "Okta"
+  - "Twilio"
+  - "SendGrid"
+  - "Git"
+  - "GitHub"
+  - "ZenHub"
+  - "SonarCloud"
+  - "Dependabot"
+  - "Snyk"
+```
+
+**Decisions:**
+
+- Split `"HTML / CSS"` → HTML + CSS.
+- Split `"React in TypeScript with Apollo"` → React + TypeScript + Apollo.
+- Split `"Java / Spring Boot"` → Java + Spring Boot.
+- Split `"Git / GitHub"` → Git + GitHub.
+- Dropped `"Respondent"` — user-research recruiting service, not engagement tech (HR tooling, like Lever).
+- Dropped `"SmartyStreets"` — utility service that doesn't merit a tag; revisit if the canonical list grows to include third-party address-verification tools.
+- Dropped `"Experian"` — same logic (third-party identity service used utility-style).
+
+## Sample 3 — `_projects/usaf_gearfit.md`
+
+Practice-heavy; gold-standard case study; tags include many person names.
+
+**Before (excerpt — tags only):**
+
+```yaml
+tags:
+  - "service delivery"
+  - "research & design"
+  - "product management"
+  - "software delivery"
+  - "legacy modernization"
+  - "devops"
+  - "cloud & platforms"
+  - "data & analytics"
+  - "apis"
+  - "security & privacy"
+  - "defense"
+  - "air force"
+  - "mical nobel"
+  - "phoebe espiritu"
+  - "lesley evans"
+  - "adam weber"
+  - "nick clyde"
+  - "mitchell sipus"
+  - "maya benari"
+  - "kari hodges"
+```
+
+**After:**
+
+```yaml
+tags:
+  - "service delivery"
+  - "research & design"
+  - "product management"
+  - "software delivery"
+  - "legacy modernization"
+  - "devops"
+  - "cloud & platforms"
+  - "data & analytics"
+  - "apis"
+  - "security & privacy"
+  - "defense"
+  - "air force"
+```
+
+**Decisions:**
+
+- Dropped all 8 person-name tags. Authors are already captured in `project_members:`; tags are topic-only after this rationalization.
+- All other tags kept — they're capabilities + mission areas (matches the cleaned filters.yml taxonomy).
+
+## Known ambiguities — case studies to surface for editorial review
+
+The full 64-case-study migration will surface ~5–10 cases that need engagement-lead input. From a quick scan:
+
+| Case study | Ambiguity |
+|---|---|
+| `18f_consulting.md` | "Performance profiles" practice — kept as-is or mapped to performance-management? Above I mapped; portfolio owner should confirm. |
+| Several CDC engagements | Tech list includes parenthetical "(Cloud One)" — DOD context, but these are CDC studies. Likely copy-paste errors? Worth a quick author check. |
+| Several with "AWS / Terraform" composite | Trivial split, but the composite suggests the author meant "AWS, deployed via Terraform" — same as having both separately. Confirm. |
+| Older studies with "Excel" | Drop as tooling noise, or keep? Depends on whether Excel was the engagement deliverable medium (rare but possible). |
+
+## Validation pattern (after migration)
+
+Once these case studies migrate AND the linter extension lands in skylight-hub, every `_projects/*.md` will be checked:
+
+- Each `technologies:` entry must match a canonical `display_name` or `alias` in `_data/technologies.yml`
+- Same for `practices:` → `_data/practices.yml`
+- Same for `tags:` → `_data/filters.yml` (or a new `_data/tags.yml` if tags get their own file post-cleanup)
+
+Unknown values become blocking linter findings, forcing a deliberate canonical-list update (adding a new entry) rather than silent drift.
+
+## Cross-references
+
+- Strategic proposal: [`skylight-hub-proposals-resolve/proposals/active/website-filter-rationalization.md`](https://github.com/skylight-hq/skylight-hub/blob/main/skylight-hub-proposals-resolve/proposals/active/website-filter-rationalization.md)
+- Operational migration plan: [`skylight-hub/migrations/case-study-taxonomy-rationalization.md`](https://github.com/skylight-hq/skylight-hub/blob/main/migrations/case-study-taxonomy-rationalization.md)
+- Filters pack plan: [`skylight-hub/migrations/website-filters-pack.md`](https://github.com/skylight-hq/skylight-hub/blob/main/migrations/website-filters-pack.md)

--- a/_data/practices.yml
+++ b/_data/practices.yml
@@ -1,0 +1,532 @@
+# Canonical practice taxonomy for case studies.
+#
+# Source of truth for `practices:` values in `_projects/*.md` frontmatter.
+# The website-case-study-linter (in skylight-hub) validates that every
+# `practices:` value either matches a canonical `display_name` here or
+# matches one of an entry's `aliases:`.
+#
+# Conventions:
+#   - One practice per entry. "Coaching & training" is two entries (coaching,
+#     training) or one consolidated entry if they're rarely separable in
+#     Skylight's work.
+#   - Consolidate near-duplicates aggressively. "Accessibility" / "Accessibility
+#     design" / "Accessibility review" / "Accessible design" are one canonical
+#     with multiple aliases.
+#   - Drop unhelpful over-specializations. "Agile cloud migration" is "agile"
+#     applied to a cloud-migration engagement; tag both `agile` and the
+#     migration type separately rather than coining a new practice.
+#
+# Adding a new entry: open a PR. Reviewers: case-study portfolio owner (TBD).
+
+practices:
+
+  # ============================================================
+  # Delivery process + methodology
+  # ============================================================
+
+  - id: agile
+    display_name: Agile development
+    category: delivery
+    aliases:
+      - Agile
+      - Agile / digital acquisition
+      - Agile cloud migration
+      - Agile product management
+      - Agile workshop facilitation
+    notes: |
+      Consolidates over-specialized Agile variants. Specific applications
+      (e.g., agile coaching, agile workshop facilitation) should tag both
+      `agile` and the specific practice (coaching, workshop-facilitation).
+
+  - id: scrum
+    display_name: Scrum framework
+    category: delivery
+
+  - id: lean-startup
+    display_name: Lean startup
+    category: delivery
+
+  - id: lean-product
+    display_name: Lean product
+    category: delivery
+
+  - id: okr
+    display_name: Objectives and key results framework
+    category: delivery
+    aliases: [OKRs, OKR]
+
+  - id: iterative-incremental-development
+    display_name: Iterative and incremental development
+    category: delivery
+
+  - id: continuous-improvement
+    display_name: Continuous improvement
+    category: delivery
+
+  - id: management-by-objectives
+    display_name: Management by objectives
+    category: delivery
+
+  - id: rapid-prototyping
+    display_name: Rapid prototyping
+    category: delivery
+
+  - id: prototyping
+    display_name: Prototyping
+    category: delivery
+
+  - id: pairing
+    display_name: Pair programming
+    category: delivery
+    aliases: [Pairing]
+
+  - id: spike-solutions
+    display_name: Spike solutions
+    category: delivery
+
+  - id: user-story-writing
+    display_name: User story writing and estimation
+    category: delivery
+    aliases:
+      - Story writing
+      - Story estimation
+      - Velocity calculation
+
+  # ============================================================
+  # Research
+  # ============================================================
+
+  - id: user-research
+    display_name: User research
+    category: research
+    aliases:
+      - Customer research
+      - Generative user research
+      - Evaluative user research
+      - Moderated user research
+      - Unmoderated user research
+    notes: |
+      Umbrella for user-facing research. Specific methods get their own
+      entries (interviews, surveys, usability-testing) and a case study
+      can tag both `user-research` and the specific method.
+
+  - id: user-interviews
+    display_name: User interviews
+    category: research
+    aliases:
+      - Stakeholder interviews
+      - Customer and stakeholder interviews
+      - Trauma-informed interviewing
+
+  - id: usability-testing
+    display_name: Usability testing
+    category: research
+    aliases: [User testing]
+
+  - id: primary-research
+    display_name: Primary research
+    category: research
+
+  - id: secondary-research
+    display_name: Secondary research
+    category: research
+    aliases:
+      - Industry research
+      - Market research
+      - Policy research
+      - Comparative analysis
+      - Industry benchmarking
+
+  - id: research-analysis
+    display_name: Research analysis and synthesis
+    category: research
+    aliases:
+      - Analysis and synthesis
+      - Information gathering
+      - Semantic analysis
+
+  - id: surveys
+    display_name: Surveys
+    category: research
+
+  - id: card-sorting
+    display_name: Card sorting
+    category: research
+
+  - id: tree-testing
+    display_name: Tree testing
+    category: research
+
+  - id: journey-mapping
+    display_name: Journey mapping
+    category: research
+
+  - id: persona-development
+    display_name: Persona development
+    category: research
+
+  - id: stakeholder-mapping
+    display_name: Stakeholder mapping
+    category: research
+
+  # ============================================================
+  # Design
+  # ============================================================
+
+  - id: ux-design
+    display_name: User experience design
+    category: design
+    aliases:
+      - UX design
+      - User-centered design
+      - User centered design
+
+  - id: visual-design
+    display_name: Visual design
+    category: design
+    aliases: [Branding design, Product design]
+
+  - id: visual-design-audit
+    display_name: Visual design audit
+    category: design
+
+  - id: content-design
+    display_name: Content design
+    category: design
+    aliases:
+      - Content strategy
+      - Content guidelines
+      - Plain-language writing
+
+  - id: information-architecture
+    display_name: Information architecture
+    category: design
+
+  - id: service-design
+    display_name: Service design
+    category: design
+
+  - id: service-blueprinting
+    display_name: Service blueprinting
+    category: design
+
+  - id: design-system
+    display_name: Design system
+    category: design
+    aliases: [Custom design system, Design pattern library]
+
+  - id: accessibility-design
+    display_name: Accessibility design
+    category: design
+    aliases:
+      - Accessibility
+      - Accessibility review
+      - Accessible design
+      - WCAG 2.0
+
+  - id: responsive-design
+    display_name: Responsive design
+    category: design
+    aliases: [Responsive web design, Mobile-first design]
+
+  - id: design-workshops
+    display_name: Design workshops
+    category: design
+    aliases: [Design studios, Collaborative design workshops, Prioritization workshops]
+
+  - id: wireframing
+    display_name: Wireframing
+    category: design
+
+  - id: participatory-design
+    display_name: Participatory design
+    category: design
+
+  - id: design-leadership
+    display_name: Design leadership
+    category: design
+
+  # ============================================================
+  # Engineering + ops
+  # ============================================================
+
+  - id: api-first-development
+    display_name: API-first development
+    category: engineering
+
+  - id: api-design
+    display_name: API design
+    category: engineering
+    aliases:
+      - API governance
+      - API management
+      - RESTful API architecture
+      - "RESTful / SOAP API architecture"
+      - "RESTful, HATEOAS API architecture"
+      - API encapsulation
+      - API service composition
+      - REST API wrapper
+
+  - id: api-deployment
+    display_name: API deployment
+    category: engineering
+
+  - id: microservices-architecture
+    display_name: Microservices architecture
+    category: engineering
+    notes: |
+      Some case studies tag this as a `technology: microservices`. Prefer
+      the practices entry when describing the architectural choice; use
+      the technology tag only when a specific microservices framework is
+      named.
+
+  - id: containerization
+    display_name: Containerization
+    category: engineering
+
+  - id: cloud-hosting
+    display_name: Cloud hosting
+    category: engineering
+
+  - id: hybrid-cloud
+    display_name: Hybrid-cloud architecture
+    category: engineering
+
+  - id: legacy-modernization
+    display_name: Legacy modernization
+    category: engineering
+    aliases:
+      - Legacy reengineering / strangler pattern
+      - Live redevelopment
+
+  - id: devsecops
+    display_name: DevSecOps
+    category: ops
+
+  - id: devops
+    display_name: DevOps
+    category: ops
+
+  - id: continuous-integration
+    display_name: Continuous integration
+    category: ops
+
+  - id: deployment-automation
+    display_name: Deployment automation
+    category: ops
+    aliases: [Programmatic deployment scripts]
+
+  - id: infrastructure-as-code
+    display_name: Infrastructure as code
+    category: ops
+
+  - id: automated-testing
+    display_name: Automated testing
+    category: ops
+
+  - id: automated-documentation
+    display_name: Automated documentation
+    category: ops
+
+  - id: health-checks
+    display_name: Health checks
+    category: ops
+
+  - id: security-privacy-compliance
+    display_name: Security and privacy compliance
+    category: ops
+    aliases: ["Security / privacy compliance"]
+
+  - id: identity-access-management
+    display_name: Identity and access management
+    category: ops
+
+  - id: security-controls-automation
+    display_name: Security controls automation
+    category: ops
+
+  # ============================================================
+  # Product + strategy
+  # ============================================================
+
+  - id: product-management
+    display_name: Product management
+    category: product
+
+  - id: data-strategy
+    display_name: Data strategy
+    category: product
+
+  - id: data-management
+    display_name: Data management
+    category: product
+
+  - id: data-engineering
+    display_name: Data engineering
+    category: product
+
+  # ============================================================
+  # Coaching, training, capability
+  # ============================================================
+
+  - id: coaching-training
+    display_name: Coaching and training
+    category: coaching-training
+    aliases:
+      - Coaching
+      - Training
+      - Coaching & training
+      - Training and coaching
+      - Peer mentoring and coaching
+
+  - id: capability-development
+    display_name: Capability development
+    category: coaching-training
+
+  - id: classroom-training
+    display_name: Classroom training
+    category: coaching-training
+
+  - id: instructional-design
+    display_name: Instructional design
+    category: coaching-training
+
+  - id: learning-by-doing
+    display_name: Learning by doing
+    category: coaching-training
+
+  - id: train-the-trainer
+    display_name: Train the trainer
+    category: coaching-training
+
+  - id: communities-of-practice
+    display_name: Communities of practice
+    category: coaching-training
+    aliases: ["Communities of Practice (CoP)", CoP]
+
+  - id: knowledge-management
+    display_name: Knowledge management
+    category: coaching-training
+
+  # ============================================================
+  # Facilitation + collaboration
+  # ============================================================
+
+  - id: workshop-facilitation
+    display_name: Workshop facilitation
+    category: facilitation
+
+  - id: virtual-collaboration
+    display_name: Virtual collaboration
+    category: facilitation
+    aliases: [Virtual teams, Remote teams]
+
+  - id: co-located-teams
+    display_name: Co-located teams
+    category: facilitation
+
+  - id: team-building
+    display_name: Team building
+    category: facilitation
+
+  # ============================================================
+  # Acquisition + procurement
+  # ============================================================
+
+  - id: digital-acquisition
+    display_name: Digital acquisition
+    category: acquisition
+
+  - id: acquisition-planning
+    display_name: Acquisition planning
+    category: acquisition
+
+  - id: challenge-based-acquisition
+    display_name: Challenge-based acquisition
+    category: acquisition
+
+  - id: best-value-contracting
+    display_name: Best-value contracting
+    category: acquisition
+
+  - id: public-domain-contracting
+    display_name: Public-domain contracting
+    category: acquisition
+
+  - id: vendor-outreach
+    display_name: Vendor outreach
+    category: acquisition
+
+  - id: analysis-of-alternatives
+    display_name: Analysis of alternatives
+    category: acquisition
+
+  # ============================================================
+  # Consulting + leadership
+  # ============================================================
+
+  - id: consulting
+    display_name: Consulting
+    category: consulting
+
+  - id: technical-discovery
+    display_name: Technical discovery
+    category: consulting
+
+  - id: servant-leadership
+    display_name: Servant leadership
+    category: consulting
+
+  - id: team-of-teams
+    display_name: Team of teams
+    category: consulting
+
+  - id: open-source-development
+    display_name: Open-source development
+    category: engineering
+    aliases: [Open innovation]
+
+  - id: user-growth-marketing
+    display_name: User growth marketing
+    category: product
+
+  # ============================================================
+  # Recruiting (rare; for spotlight-adjacent case studies)
+  # ============================================================
+
+  - id: civic-recruiting
+    display_name: Civic recruiting
+    category: recruiting
+
+  - id: schedule-a-hiring
+    display_name: Schedule A(r) hiring authority
+    category: recruiting
+
+  - id: talent-management
+    display_name: Talent management
+    category: recruiting
+
+  - id: performance-management
+    display_name: Performance management
+    category: recruiting
+
+# ============================================================
+# Migration notes — entries from case studies on `main` (2026-05-20)
+# that need explicit handling during the rationalization migration:
+#
+#   - "Web and native apps" — too broad to be a practice; drop, or split
+#     into individual technologies tagged elsewhere
+#   - "Spidering" — describes a one-off implementation detail; drop
+#   - "Touchpoints" — proper noun (a federal tool); should be a technology
+#   - "Existing technology stack" — non-answer; drop
+#   - "Google interview practices" — vague; drop unless the case study
+#     is specifically about Google-style interviewing
+#   - "Trauma-informed interviewing" — niche but real; kept as aliased
+#     under user-interviews
+#   - "Plain-language writing" — kept as aliased under content-design;
+#     case studies about plain-language coaching should also tag
+#     coaching-training
+#   - "Live redevelopment" — captured under legacy-modernization
+#   - Several over-specialized API entries — consolidated under api-design
+#
+# Per-case-study migration tracked in skylight-hub/migrations/case-study-taxonomy-rationalization.md.

--- a/_data/technologies.yml
+++ b/_data/technologies.yml
@@ -1,0 +1,704 @@
+# Canonical technology taxonomy for case studies.
+#
+# Source of truth for `technologies:` values in `_projects/*.md` frontmatter.
+# The website-case-study-linter (in skylight-hub) validates that every
+# `technologies:` value either matches a canonical `display_name` here or
+# matches one of an entry's `aliases:`.
+#
+# Conventions:
+#   - Atomic, not composite. "JavaScript / React / TypeScript" is three entries.
+#   - Vendor-product disambiguated. AWS is the vendor; Lambda/S3/RDS are products.
+#   - Context noise stripped. No "(Cloud One)", "(recruiting software)" parentheticals.
+#   - Display name = how it shows in case-study frontmatter and on the website.
+#   - id = kebab-case canonical identifier (stable; never renamed).
+#   - aliases = alternate spellings recognized during migration/validation.
+#
+# Adding a new entry: open a PR. Reviewers: case-study portfolio owner (TBD).
+
+technologies:
+
+  # ============================================================
+  # Programming languages
+  # ============================================================
+
+  - id: javascript
+    display_name: JavaScript
+    category: language
+    aliases: [JS]
+
+  - id: typescript
+    display_name: TypeScript
+    category: language
+    aliases: [TS]
+
+  - id: python
+    display_name: Python
+    category: language
+
+  - id: ruby
+    display_name: Ruby
+    category: language
+
+  - id: java
+    display_name: Java
+    category: language
+
+  - id: dotnet
+    display_name: .NET
+    category: language
+    aliases: [.NET Core]
+
+  - id: go
+    display_name: Go
+    category: language
+    aliases: [Golang]
+
+  - id: clojure
+    display_name: Clojure
+    category: language
+
+  - id: clojurescript
+    display_name: ClojureScript
+    category: language
+
+  - id: erlang
+    display_name: Erlang
+    category: language
+
+  - id: groovy
+    display_name: Groovy
+    category: language
+
+  - id: html
+    display_name: HTML
+    category: language
+
+  - id: css
+    display_name: CSS
+    category: language
+
+  - id: sass
+    display_name: Sass
+    category: language
+
+  - id: svg
+    display_name: SVG
+    category: language
+
+  - id: yaml
+    display_name: YAML
+    category: language
+
+  - id: sql
+    display_name: SQL
+    category: language
+
+  # ============================================================
+  # Frontend frameworks + libraries
+  # ============================================================
+
+  - id: react
+    display_name: React
+    category: frontend
+    aliases: [React.js, ReactJS]
+
+  - id: vue
+    display_name: Vue.js
+    category: frontend
+    aliases: [Vue]
+
+  - id: backbone
+    display_name: Backbone.js
+    category: frontend
+    aliases: [Backbone]
+
+  - id: stencil
+    display_name: Stencil
+    category: frontend
+
+  - id: web-components
+    display_name: Web Components
+    category: frontend
+    aliases: [Web components]
+
+  - id: redux
+    display_name: Redux
+    category: frontend
+
+  - id: apollo
+    display_name: Apollo
+    category: frontend
+
+  # ============================================================
+  # Design systems
+  # ============================================================
+
+  - id: uswds
+    display_name: U.S. Web Design System
+    category: design-system
+    aliases: [USWDS]
+
+  - id: carbon-design-system
+    display_name: Carbon Design System
+    category: design-system
+
+  - id: material-ui
+    display_name: Material-UI
+    category: design-system
+
+  - id: material-design
+    display_name: Material Design
+    category: design-system
+    aliases: [Google Material Design]
+
+  - id: bootstrap
+    display_name: Bootstrap
+    category: design-system
+    aliases: [Twitter Bootstrap]
+
+  - id: polaris
+    display_name: Polaris Design System
+    category: design-system
+
+  - id: semantic-ui
+    display_name: Semantic UI
+    category: design-system
+
+  - id: tailwind-ui
+    display_name: Tailwind UI
+    category: design-system
+
+  # ============================================================
+  # Backend frameworks + runtimes
+  # ============================================================
+
+  - id: rails
+    display_name: Ruby on Rails
+    category: backend
+    aliases: [Rails, "Ruby / Rails"]
+
+  - id: spring-boot
+    display_name: Spring Boot
+    category: backend
+    aliases: ["Java / Spring Boot"]
+
+  - id: django
+    display_name: Django
+    category: backend
+    aliases: ["Python / Django"]
+
+  - id: express
+    display_name: Express.js
+    category: backend
+    aliases: [Express]
+
+  - id: node
+    display_name: Node.js
+    category: backend
+    aliases: [Node, NodeJS]
+
+  # ============================================================
+  # Cloud platforms
+  # ============================================================
+
+  - id: aws
+    display_name: Amazon Web Services
+    category: cloud-platform
+    aliases: [AWS, "AWS (Cloud One)", "cloud.gov / Amazon Web Services"]
+    notes: |
+      Use this for the platform reference. AWS services (Lambda, S3, etc.)
+      get their own entries below.
+
+  - id: azure
+    display_name: Microsoft Azure
+    category: cloud-platform
+    aliases: [Azure]
+
+  - id: azure-iot
+    display_name: Azure IoT
+    category: cloud-platform
+
+  - id: cloud-gov
+    display_name: cloud.gov
+    category: cloud-platform
+
+  - id: heroku
+    display_name: Heroku
+    category: cloud-platform
+
+  # ============================================================
+  # AWS services
+  # ============================================================
+
+  - id: aws-lambda
+    display_name: AWS Lambda
+    category: cloud-service
+    aliases: ["AWS Lambda (Cloud One)"]
+
+  - id: aws-rds
+    display_name: Amazon RDS
+    category: cloud-service
+    aliases: ["Amazon RDS for PostgreSQL", "AWS RDS Oracle (Cloud One)"]
+
+  - id: aws-s3
+    display_name: Amazon S3
+    category: cloud-service
+    aliases: [S3, "S3 Bucket"]
+
+  - id: aws-cloudfront
+    display_name: Amazon CloudFront
+    category: cloud-service
+
+  - id: aws-fargate
+    display_name: AWS Fargate
+    category: cloud-service
+
+  - id: aws-elastic-beanstalk
+    display_name: AWS Elastic Beanstalk
+    category: cloud-service
+    aliases: ["AWS Elastic Beanstalk (Cloud One)"]
+
+  - id: aws-emr
+    display_name: Amazon EMR
+    category: cloud-service
+
+  # ============================================================
+  # Containers + orchestration
+  # ============================================================
+
+  - id: docker
+    display_name: Docker
+    category: containers
+
+  - id: microservices
+    display_name: Microservices
+    category: architecture-pattern
+    notes: |
+      Pattern, not a specific tool. Some case studies may better categorize
+      as `practices: microservices-architecture`; consider during migration.
+
+  # ============================================================
+  # Infrastructure as code
+  # ============================================================
+
+  - id: terraform
+    display_name: Terraform
+    category: infrastructure-as-code
+
+  - id: puppet
+    display_name: Puppet
+    category: infrastructure-as-code
+
+  - id: chef
+    display_name: Chef
+    category: infrastructure-as-code
+
+  - id: packer
+    display_name: Packer
+    category: infrastructure-as-code
+
+  # ============================================================
+  # CI/CD
+  # ============================================================
+
+  - id: github-actions
+    display_name: GitHub Actions
+    category: ci-cd
+
+  - id: gitlab-ci
+    display_name: GitLab CI/CD
+    category: ci-cd
+
+  - id: jenkins
+    display_name: Jenkins
+    category: ci-cd
+
+  - id: circleci
+    display_name: CircleCI
+    category: ci-cd
+
+  - id: azure-devops
+    display_name: Azure DevOps
+    category: ci-cd
+
+  - id: octopus-deploy
+    display_name: Octopus Deploy
+    category: ci-cd
+
+  # ============================================================
+  # Version control + repo hosting
+  # ============================================================
+
+  - id: git
+    display_name: Git
+    category: version-control
+
+  - id: github
+    display_name: GitHub
+    category: version-control
+    aliases: ["Git / GitHub"]
+
+  - id: gitlab
+    display_name: GitLab
+    category: version-control
+    aliases: ["Git / GitLab"]
+
+  - id: github-pages
+    display_name: GitHub Pages
+    category: version-control
+    aliases: [Federalist, "Federalist / GitHub Pages", "GitHub Pages / Jekyll"]
+
+  # ============================================================
+  # Databases + search
+  # ============================================================
+
+  - id: postgresql
+    display_name: PostgreSQL
+    category: data
+
+  - id: mysql
+    display_name: MySQL
+    category: data
+
+  - id: sql-server
+    display_name: SQL Server
+    category: data
+
+  - id: db2
+    display_name: DB2
+    category: data
+    aliases: ["DB2 / DB2 stored procedures"]
+
+  - id: rethinkdb
+    display_name: RethinkDB
+    category: data
+
+  - id: elasticsearch
+    display_name: Elasticsearch
+    category: data
+
+  - id: sqlalchemy
+    display_name: SQLAlchemy
+    category: data
+
+  - id: sequel
+    display_name: Sequel
+    category: data
+
+  - id: liquibase
+    display_name: Liquibase
+    category: data
+
+  # ============================================================
+  # API tools + protocols
+  # ============================================================
+
+  - id: graphql
+    display_name: GraphQL
+    category: api
+
+  - id: openapi
+    display_name: OpenAPI Specification
+    category: api
+    aliases: [Swagger]
+
+  - id: rest
+    display_name: REST
+    category: api
+
+  - id: soap
+    display_name: SOAP
+    category: api
+    aliases: ["SOAP API"]
+
+  - id: json-api
+    display_name: JSON:API
+    category: api
+    aliases: ["JSON API"]
+
+  - id: websockets
+    display_name: WebSockets
+    category: api
+
+  # ============================================================
+  # Identity + auth
+  # ============================================================
+
+  - id: oauth
+    display_name: OAuth
+    category: identity
+
+  - id: keycloak
+    display_name: Keycloak
+    category: identity
+
+  - id: okta
+    display_name: Okta
+    category: identity
+
+  - id: identityserver
+    display_name: IdentityServer
+    category: identity
+
+  # ============================================================
+  # Static site + CMS
+  # ============================================================
+
+  - id: jekyll
+    display_name: Jekyll
+    category: cms
+
+  - id: mkdocs
+    display_name: MkDocs
+    category: cms
+
+  - id: brightspot
+    display_name: Brightspot CMS
+    category: cms
+
+  - id: wordpress
+    display_name: WordPress
+    category: cms
+
+  - id: sitecore
+    display_name: Sitecore
+    category: cms
+
+  # ============================================================
+  # Healthcare / domain standards
+  # ============================================================
+
+  - id: fhir
+    display_name: FHIR
+    category: domain-standard
+    aliases: ["Azure Managed FHIR Server"]
+
+  - id: hl7
+    display_name: HL7
+    category: domain-standard
+
+  # ============================================================
+  # Testing
+  # ============================================================
+
+  - id: jest
+    display_name: Jest
+    category: testing
+
+  - id: mocha
+    display_name: Mocha
+    category: testing
+
+  - id: cypress
+    display_name: Cypress
+    category: testing
+
+  - id: nightwatch
+    display_name: Nightwatch
+    category: testing
+
+  - id: jmeter
+    display_name: JMeter
+    category: testing
+
+  - id: storybook
+    display_name: Storybook
+    category: testing
+
+  - id: chromatic
+    display_name: Chromatic
+    category: testing
+
+  # ============================================================
+  # Security + observability
+  # ============================================================
+
+  - id: sonarcloud
+    display_name: SonarCloud
+    category: security
+
+  - id: snyk
+    display_name: Snyk
+    category: security
+
+  - id: dependabot
+    display_name: Dependabot
+    category: security
+
+  - id: splunk
+    display_name: Splunk
+    category: observability
+
+  - id: lighthouse
+    display_name: Lighthouse
+    category: observability
+
+  - id: google-analytics
+    display_name: Google Analytics
+    category: observability
+
+  # ============================================================
+  # Design tools
+  # ============================================================
+
+  - id: figma
+    display_name: Figma
+    category: design-tool
+
+  - id: figjam
+    display_name: FigJam
+    category: design-tool
+
+  - id: sketch
+    display_name: Sketch
+    category: design-tool
+
+  - id: invision
+    display_name: InVision
+    category: design-tool
+
+  - id: adobe-xd
+    display_name: Adobe XD
+    category: design-tool
+
+  - id: balsamiq
+    display_name: Balsamiq
+    category: design-tool
+
+  - id: lucidchart
+    display_name: Lucidchart
+    category: design-tool
+
+  - id: mural
+    display_name: Mural
+    category: design-tool
+
+  # ============================================================
+  # Collaboration + productivity
+  # ============================================================
+
+  - id: slack
+    display_name: Slack
+    category: collaboration
+
+  - id: mattermost
+    display_name: Mattermost
+    category: collaboration
+
+  - id: teams
+    display_name: Microsoft Teams
+    category: collaboration
+
+  - id: zoom
+    display_name: Zoom
+    category: collaboration
+
+  - id: google-workspace
+    display_name: Google Workspace
+    category: collaboration
+
+  - id: microsoft-office
+    display_name: Microsoft Office
+    category: collaboration
+
+  - id: confluence
+    display_name: Confluence
+    category: collaboration
+
+  - id: trello
+    display_name: Trello
+    category: collaboration
+
+  - id: jira
+    display_name: Jira
+    category: collaboration
+
+  - id: zenhub
+    display_name: ZenHub
+    category: collaboration
+
+  - id: smartsheets
+    display_name: Smartsheets
+    category: collaboration
+
+  - id: airtable
+    display_name: Airtable
+    category: collaboration
+
+  - id: box
+    display_name: Box
+    category: collaboration
+
+  - id: sharepoint
+    display_name: Microsoft SharePoint
+    category: collaboration
+
+  # ============================================================
+  # Communications (email + SMS)
+  # ============================================================
+
+  - id: twilio
+    display_name: Twilio
+    category: communications
+
+  - id: sendgrid
+    display_name: SendGrid
+    category: communications
+
+  - id: campaign-monitor
+    display_name: Campaign Monitor
+    category: communications
+
+  # ============================================================
+  # Mobile
+  # ============================================================
+
+  - id: flutter
+    display_name: Flutter
+    category: mobile
+
+  - id: ios-sdk
+    display_name: iOS SDK
+    category: mobile
+
+  - id: android-sdk
+    display_name: Android SDK
+    category: mobile
+
+  # ============================================================
+  # Specialized / domain
+  # ============================================================
+
+  - id: 6lowpan
+    display_name: 6LoWPAN
+    category: domain-standard
+    notes: IoT-specific protocol; used in case studies involving sensor networks.
+
+  - id: mems
+    display_name: MEMS
+    category: domain-standard
+    notes: Microelectromechanical systems; IoT hardware context.
+
+# ============================================================
+# Migration notes — entries from case studies on `main` (2026-05-20)
+# that do NOT migrate cleanly to a canonical entry above:
+#
+#   - "Apple" (vendor name as tech; drop)
+#   - "Existing technology stack" (non-answer; drop)
+#   - "Custom spidering script" (described, not a technology; drop)
+#   - "Temporary URLs" (concept, not technology; drop)
+#   - "Instructional media" (category, not technology; drop)
+#   - "Spidering" (likely a practice; reclassify or drop)
+#   - "appear.in" (dead product; drop)
+#   - "Lever (recruiting software)" / "Workable (recruiting software)" (HR
+#     tooling, not engagement tech; drop unless case study is HR-specific)
+#   - "Adobe Connect" (legacy product; drop unless case study is from that era)
+#   - "Excel" (consider whether worth tagging; lean drop)
+#   - "Microsoft Office" (vague; keep as `microsoft-office` if appropriate)
+#   - "AWS / Terraform" (composite; split into aws + terraform)
+#   - "Jest / Mocha / Karma / Jasmine / Supertest" (composite; split into
+#     individual entries; karma/jasmine/supertest may be too long-tail to keep)
+#   - "JavaScript / React / TypeScript" and 6 other React composites (split)
+#   - "HTML / CSS / Sass / SVG" and other style composites (split)
+#
+# Per-case-study migration tracked in skylight-hub/migrations/case-study-taxonomy-rationalization.md.


### PR DESCRIPTION
## Summary

Phase 1 of the [website-filter-rationalization proposal](https://github.com/skylight-hq/skylight-hub/blob/main/proposals/active/website-filter-rationalization.md). Ships the two canonical taxonomy lists this site has been missing — the source of truth for `technologies:` and `practices:` values in `_projects/*.md` frontmatter.

**Files:**
- `_data/technologies.yml` — **134 entries** with `id` / `display_name` / `category` / `aliases`, grouped into 14 categories (languages, frameworks, clouds, data, identity, observability, etc.).
- `_data/practices.yml` — **91 entries** with `id` / `display_name` / `category` / `aliases` / `notes`, grouped by Skylight practice area.
- `_data/_taxonomy_migration_notes.md` — companion doc with 3 worked sample case-study migrations (`18f_consulting`, `cdc_simplereport`, `usaf_gearfit`), general mapping rules, and known editorial ambiguities for the 64-case-study migration follow-up.

**Schema conventions** (documented in the file headers):
- `id` = stable kebab-case canonical identifier (never renamed).
- `display_name` = how it appears in case-study frontmatter and on the website.
- `aliases` = alternate spellings recognized during validation/migration.
- `category` = grouping bucket (informational; not validated).
- Atomic, not composite. `JavaScript / React / TypeScript` is three entries, not one.

**Drift fix during prep:** removed a duplicate `keycloak` entry that appeared in both the `identity` and `specialized/domain` sections.

## What this unblocks

1. **`skylight-hub/migrations/case-study-taxonomy-rationalization.md`** — the 64-case-study free-text → canonical migration can finally execute.
2. **`skylight-website-filters-pack` sync workflow** — runs Mondays and currently 404s on these two files. Next sync after this merges will vendor them into the hub and stop the SKIP.
3. **Website-case-study-linter taxonomy-validation rules** — `case_study.taxonomy_unknown` can flip from advisory to blocking.

## Test plan

- [x] Both YAML files parse cleanly via `YAML.safe_load` with no duplicate ids.
- [x] All entries have the three required keys (`id`, `display_name`, `category`).
- [ ] Jekyll build succeeds (CI).
- [ ] The `_data/` files are accessible as `site.data.technologies.technologies` / `site.data.practices.practices` for any future template that wants them. (Not consumed yet — wired in by the case-study migration follow-up.)