### PR TITLE
Phase 4: triage taxonomy unknowns (add 10 techs + 11 aliases + drop-rules)

### DIFF
--- a/_data/_taxonomy_migration_notes.md
+++ b/_data/_taxonomy_migration_notes.md
@@ -22,6 +22,56 @@ The full per-case-study migration is tracked in [`skylight-hub/migrations/case-s
 | Drop person names already in project_members | If "chris-cairns" is in `project_members:`, "chris cairns" gets dropped from `tags:` |
 | Tags should be topic-only | After migration, `tags:` contains capability / mission / topic — no person names |
 
+## Known drops — values to remove during Phase 3 migration
+
+Triaged from the full-corpus run of `scripts/map_case_study_taxonomies.rb` (skylight-hub) on 2026-05-26. These specific values do **not** map to any canonical and should be dropped from the case study's frontmatter rather than kept as free-text. Phase 3 reviewers can apply these decisions in bulk without per-case-study judgment:
+
+### Drop from `technologies:`
+
+| Value | Reason |
+|---|---|
+| `"APIs"` (×18) | Capability tag misfield'd into technologies. Already covered by the `apis` tag from `filters.yml`; drop from `technologies:`. |
+| `"Apple"` | Vendor name as tech; not a technology. |
+| `"Existing technology stack"` | Non-answer. |
+| `"Temporary URLs"` | Concept, not a technology. |
+| `"Custom spidering script"` | Description, not a technology. |
+| `"Instructional media"` | Category, not a technology. |
+| `"Automated testing frameworks"` | Category, not a specific framework. |
+| `"appear.in"` | Dead product (shut down 2022). |
+| `"Lever (recruiting software)"`, `"Workable (recruiting software)"` | HR tooling. Drop unless the case study is HR-specific. |
+| `"Respondent"` | User-research recruiting service. Utility-style; not engagement tech. |
+| `"SmartyStreets"`, `"Experian"` | Third-party utility services (address-verification, identity). Drop unless the case study foregrounds them. |
+| `"SurveyMonkey"`, `"Adobe Connect"`, `"Chrome Web Developer Toolkit"`, `"Colour Contrast Analyzer"`, `"Google Accessibility Audit Tools"`, `"Wave"` | Generic utility/diagnostic tools, not engagement-defining tech. |
+| `"Excel"` | Tooling noise unless Excel was the actual engagement deliverable (rare). |
+| `"AJAX"`, `"JSON"`, `"IoT"` | Categories/patterns, not specific technologies. (Capabilities like "apis" / "data & analytics" cover the same ground.) |
+| `"Touchpoints"` | Generic; not a specific tool. |
+| `"Microsoft Azure (Key Vault, Container Apps, WAF, Gateways, App Service)"` | Composite-with-parenthetical. Keep `Microsoft Azure`; drop the parenthetical service list. |
+| `"React in TypeScript with Apollo"` | Prose composite. Split into `React`, `TypeScript`, `Apollo` per the composite→atomic rule. |
+
+### Drop from `practices:`
+
+| Value | Reason |
+|---|---|
+| `"Web and native apps"` (×5) | Deliverable type, not a practice. |
+| `"Third-party integration"` | Engineering concept, not a Skylight practice. |
+| `"Google interview practices"` | Vague + Google-specific; not a practice we own. |
+| `"Civic crowdsourcing"` | Project-specific phrasing; not a generalizable practice. |
+| `"Oral presentations"` | Generic activity, not a practice. |
+| `"Testing"` | Too generic. Specific testing types (load testing, QA testing) get their own entries if needed. |
+| `"Intelligent protocol system development"` | Project-specific phrasing; not a generalizable practice. |
+| `"Artificial data"` | Means synthetic data; too narrow to be a practice. |
+| `"Spidering"` | Engineering technique, not a Skylight practice. |
+
+### Aliases added 2026-05-26 (no longer surface as unknown after this PR)
+
+- `User research` gains aliases for: `Qualitative research`, `Qualitative`, `Quantitative research` (mixed-case), `Quantitative analysis`, `Observation`, `Documentation review`, `User test scenarios`, `KJ technique` — all generic-method labels for what user-research already covers.
+- `Design system` gains alias: `User interface component inventory`.
+- `Performance management` gains alias: `Performance profiles`.
+
+### Tech entries added 2026-05-26 (no longer surface as unknown after this PR)
+
+`NGINX`, `Metabase`, `Jasmine`, `Karma`, `Supertest`, `tfsec`, `XMPP`, `API Umbrella`, `Caseworthy`, `Rhapsody`.
+
 ## Sample 1 — `_projects/18f_consulting.md`
 
 Most problematic case study: ancient, full of person names in tags, "Apple" as a tech, dead products.

--- a/_data/practices.yml
+++ b/_data/practices.yml
@@ -105,10 +105,23 @@ practices:
       - Evaluative user research
       - Moderated user research
       - Unmoderated user research
+      - Qualitative research
+      - Qualitative
+      - Quantitative research
+      - quantitative research
+      - Quantitative analysis
+      - Observation
+      - Documentation review
+      - User test scenarios
+      - KJ technique
     notes: |
       Umbrella for user-facing research. Specific methods get their own
       entries (interviews, surveys, usability-testing) and a case study
-      can tag both `user-research` and the specific method.
+      can tag both `user-research` and the specific method. Aliases roll
+      up: generic qualitative/quantitative labels, method-only labels
+      (KJ technique, observation, documentation review), and artifact-
+      only labels (user test scenarios) — all map back to user-research
+      since the underlying activity is the same.
 
   - id: user-interviews
     display_name: User interviews
@@ -213,7 +226,7 @@ practices:
   - id: design-system
     display_name: Design system
     category: design
-    aliases: [Custom design system, Design pattern library]
+    aliases: [Custom design system, Design pattern library, User interface component inventory]
 
   - id: accessibility-design
     display_name: Accessibility design
@@ -509,6 +522,7 @@ practices:
   - id: performance-management
     display_name: Performance management
     category: recruiting
+    aliases: [Performance profiles]
 
 # ============================================================
 # Migration notes — entries from case studies on `main` (2026-05-20)

--- a/_data/technologies.yml
+++ b/_data/technologies.yml
@@ -389,6 +389,11 @@ technologies:
     display_name: Liquibase
     category: data
 
+  - id: metabase
+    display_name: Metabase
+    category: data
+    notes: Open-source BI / data-analytics tool.
+
   # ============================================================
   # API tools + protocols
   # ============================================================
@@ -419,6 +424,18 @@ technologies:
   - id: websockets
     display_name: WebSockets
     category: api
+
+  - id: xmpp
+    display_name: XMPP
+    category: api
+    notes: Extensible Messaging and Presence Protocol (XML-based chat).
+
+  - id: api-umbrella
+    display_name: API Umbrella
+    category: api
+    notes: |
+      API management platform originating with USDS. Used in case studies
+      that fronted federal APIs (e.g., NASA Open Data, VA APIs).
 
   # ============================================================
   # Identity + auth
@@ -509,6 +526,22 @@ technologies:
     display_name: Chromatic
     category: testing
 
+  - id: jasmine
+    display_name: Jasmine
+    category: testing
+
+  - id: karma
+    display_name: Karma
+    category: testing
+    notes: |
+      JavaScript test runner. Distinct from the unrelated Apache Karma
+      project; in case studies, refers to the JS test runner.
+
+  - id: supertest
+    display_name: Supertest
+    category: testing
+    aliases: [SuperTest]
+
   # ============================================================
   # Security + observability
   # ============================================================
@@ -524,6 +557,12 @@ technologies:
   - id: dependabot
     display_name: Dependabot
     category: security
+
+  - id: tfsec
+    display_name: tfsec
+    category: security
+    aliases: [TfSec]
+    notes: Terraform configuration security scanner.
 
   - id: splunk
     display_name: Splunk
@@ -666,6 +705,15 @@ technologies:
     category: mobile
 
   # ============================================================
+  # Web servers + reverse proxies
+  # ============================================================
+
+  - id: nginx
+    display_name: NGINX
+    category: web-server
+    aliases: [nginx, Nginx]
+
+  # ============================================================
   # Specialized / domain
   # ============================================================
 
@@ -678,6 +726,16 @@ technologies:
     display_name: MEMS
     category: domain-standard
     notes: Microelectromechanical systems; IoT hardware context.
+
+  - id: caseworthy
+    display_name: Caseworthy
+    category: domain-vendor
+    notes: Case-management software for social-services delivery.
+
+  - id: rhapsody
+    display_name: Rhapsody
+    category: domain-vendor
+    notes: Orion Health healthcare-integration platform (HL7 / FHIR routing).
 
 # ============================================================
 # Migration notes — entries from case studies on `main` (2026-05-20)


### PR DESCRIPTION
## Summary

Closes the 78-unknown editorial-review surface surfaced by [skylight-hub PR #80's mapping script](https://github.com/skylight-hq/skylight-hub/pull/80) on its first full-corpus run against `_projects/*.md`.

**\`_data/technologies.yml\`**: 134 → 144 entries.

| Added | Category |
|---|---|
| Jasmine, Karma, Supertest | Testing |
| tfsec | Security (Terraform scanner) |
| Metabase | Data (BI / analytics) |
| XMPP, API Umbrella | API tools + protocols |
| NGINX | Web servers (new category) |
| Caseworthy, Rhapsody | Domain-vendor (social services / healthcare integration) |

**\`_data/practices.yml\`**: 91 entries unchanged. Aliases added to existing entries:

| Canonical | New aliases |
|---|---|
| User research | KJ technique, Observation, Documentation review, User test scenarios, Quantitative analysis, Quantitative research, quantitative research (lowercase), Qualitative, Qualitative research |
| Design system | User interface component inventory |
| Performance management | Performance profiles |

**\`_data/_taxonomy_migration_notes.md\`**: comprehensive "known drops" section added — 25+ values that should be dropped (not migrated) during Phase 3 cluster PRs. Covers technology drops (\`"APIs"\` misfield'd, HR tooling, utility services, dead products, generic patterns, prose composites) and practice drops (deliverable types, project-specific phrasing, generic activities).

## What this unblocks

After this merges + the hub's sync workflow vendors the updated YAMLs:

- Re-running \`map_case_study_taxonomies.rb\` against the corpus should drop the unknown count from **78 → ~25-30**, all of which are now explicitly documented as Phase 3 drops (not gaps in the canon).
- Phase 3 cluster PRs can start cleanly: every per-case-study migration either auto-rewrites (76%), drops person-name tags (21%), or drops per the new "known drops" rules (rest).

## Test plan

- [x] Both YAML files parse cleanly; no duplicate ids (\`technologies\`: 144 entries, \`practices\`: 91 entries).
- [x] All added entries have the three required keys (\`id\`, \`display_name\`, \`category\`).
- [ ] Netlify deploy preview builds cleanly.