### PR TITLE
Fix flow-array tags missed by cluster migrations (5 case studies)

### DIFF
--- a/_projects/ussf_web_portal.md
+++ b/_projects/ussf_web_portal.md
@@ -10,7 +10,11 @@ feature_image_description:
 feature_image_shadow:
 order: 1600
 display: true
-tags: [service delivery, research & design, defense, space force, shashank khandelwal, maya benari, zoe do]
+tags:
+  - "Service delivery"
+  - "Research & design"
+  - "Defense"
+  - "Space Force"
 excerpt: A modern portal giving the U.S. Space Force one place to share announcements, resources, and day-to-day tools with more than 15,000 Guardians.
 project_members:
   - shashank-khandelwal

--- a/_projects/va_api_developer_outreach.md
+++ b/_projects/va_api_developer_outreach.md
@@ -12,7 +12,11 @@ feature_image_description:
 feature_image_shadow:
 order: 3800
 display: true
-tags: [microconsulting, apis, open government, veterans, kin lane, chris cairns]
+tags:
+  - "Microconsulting"
+  - "APIs"
+  - "Open government"
+  - "Veterans"
 excerpt: A practical developer-outreach playbook for the VA's API platform, drawn from a decade of API research and interviews with seven leading public- and private-sector teams — and published in the open for any agency to reuse.
 project_members:
   - kin-lane

--- a/_projects/va_api_governance_research.md
+++ b/_projects/va_api_governance_research.md
@@ -12,7 +12,11 @@ feature_image_description:
 feature_image_shadow:
 order: 3400
 display: true
-tags: [microconsulting, apis, open government, veterans, kin lane, chris cairns]
+tags:
+  - "Microconsulting"
+  - "APIs"
+  - "Open government"
+  - "Veterans"
 excerpt: A practical API governance playbook for the VA's API platform, drawn from a decade of API research and interviews with seven leading public- and private-sector teams — and published in the open for any agency to reuse.
 project_members:
   - kin-lane

--- a/_projects/va_api_landscape_analysis.md
+++ b/_projects/va_api_landscape_analysis.md
@@ -11,7 +11,11 @@ feature_image:
 feature_image_description:
 order: 3500
 display: true
-tags: [microconsulting, apis, open government, veterans, kin lane, chris cairns, robert read]
+tags:
+  - "Microconsulting"
+  - "APIs"
+  - "Open government"
+  - "Veterans"
 excerpt: A two-sided map of the VA's public data surface and what veterans actually need — and a prioritized list of which datasets would be most valuable to turn into APIs.
 project_members:
   - kin-lane

--- a/_projects/va_api_scorecard_mvp.md
+++ b/_projects/va_api_scorecard_mvp.md
@@ -12,7 +12,11 @@ feature_image_description: Walkthrough of the VA API Scorecard prototype.
 feature_image_shadow: true
 order: 3000
 display: true
-tags: [microconsulting, apis, open government, veterans, victor zapanta, nick bristow, kin lane, robert read, chris cairns]
+tags:
+  - "Microconsulting"
+  - "APIs"
+  - "Open government"
+  - "Veterans"
 excerpt: A minimum viable product the VA could use to start running real governance conversations across its growing API portfolio.
 project_members:
   - victor-zapanta


### PR DESCRIPTION
5 case studies stored `tags` as single-line inline arrays (`tags: [a, b, c]`) rather than block form. The Phase 3 cluster migrations' `--write` regex only matched block form, so these files got technologies/practices migrated but tags left with person-name pollution + lowercase values. Fixed via the flow-array support added to the mapping script (skylight-hub), then re-run. All dropped names confirmed in `project_members:`. **Full-corpus verification: all 64 case studies now 100% canonical, zero drops, zero unknowns** — the rationalization frontmatter pass is complete.