### PR TITLE
Add case-study-lint CI gate (canonical taxonomy enforcement)

### DIFF
--- a/.github/workflows/case-study-lint.yml
+++ b/.github/workflows/case-study-lint.yml
@@ -1,0 +1,127 @@
+name: case-study-lint
+
+# Runs the canonical-quality case-study linter
+# (skylight-hub/plugins/skylight-website-case-study-linter) against
+# _projects/*.md. This is the regression gate for the case-study taxonomy
+# rationalization: every tags / technologies / practices value must match a
+# canonical entry in this repo's _data/{filters,technologies,practices}.yml.
+#
+# The linter is federation canon and lives in skylight-hub (a PRIVATE repo).
+# This public repo can't read it with the default GITHUB_TOKEN, so the gate
+# checks out the hub linter using a HUB_READ_TOKEN secret (a fine-grained PAT
+# with read access to skylight-hq/skylight-hub, contents:read).
+#
+#   *** ACTIVATION ***
+#   Until HUB_READ_TOKEN is added to this repo's Actions secrets, the gate
+#   SKIPS with a warning (so this workflow merges cleanly and self-activates).
+#   To activate: create a fine-grained PAT (read-only, contents, on
+#   skylight-hq/skylight-hub) and add it as the HUB_READ_TOKEN repo secret.
+#
+# Once the federation resolves hub access (e.g., hub goes public, or a shared
+# org token lands), this workflow needs no change — it already prefers the
+# secret and falls back to skipping.
+
+on:
+  pull_request:
+    paths:
+      - '_projects/**'
+      - '_data/filters.yml'
+      - '_data/technologies.yml'
+      - '_data/practices.yml'
+      - '.github/workflows/case-study-lint.yml'
+  push:
+    branches: [master]
+    paths:
+      - '_projects/**'
+      - '_data/filters.yml'
+      - '_data/technologies.yml'
+      - '_data/practices.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout skylight.digital
+        uses: actions/checkout@v4
+
+      - name: Detect hub-access token
+        id: cfg
+        env:
+          HUB_TOKEN: ${{ secrets.HUB_READ_TOKEN }}
+        run: |
+          if [ -n "$HUB_TOKEN" ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Gate inactive notice
+        if: steps.cfg.outputs.ok != 'true'
+        run: |
+          echo "::warning title=case-study-lint inactive::No HUB_READ_TOKEN secret found. " \
+               "The case-study taxonomy gate is not enforcing. Add a fine-grained PAT " \
+               "(read-only, contents, on skylight-hq/skylight-hub) as the HUB_READ_TOKEN " \
+               "repo secret to activate. Skipping for now (non-blocking)."
+          echo "Gate skipped — see warning above."
+
+      - name: Checkout skylight-hub linter (canon)
+        if: steps.cfg.outputs.ok == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: skylight-hq/skylight-hub
+          token: ${{ secrets.HUB_READ_TOKEN }}
+          path: .hub
+          sparse-checkout: |
+            plugins/skylight-website-case-study-linter
+          sparse-checkout-cone-mode: false
+
+      - name: Set up Ruby
+        if: steps.cfg.outputs.ok == 'true'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Lint all case studies against canonical taxonomy
+        if: steps.cfg.outputs.ok == 'true'
+        run: |
+          set -uo pipefail
+          LINTER=".hub/plugins/skylight-website-case-study-linter/skills/website-case-study-linter/scripts/lint_case_study.rb"
+          if [ ! -f "$LINTER" ]; then
+            echo "::error::Linter not found at $LINTER — hub layout may have changed."
+            exit 1
+          fi
+
+          failed=0
+          shopt -s nullglob
+          for f in _projects/*.md; do
+            out=$(ruby "$LINTER" "$f" --json 2>/dev/null) || true
+            # Count blocking findings via stdlib JSON.
+            blocking=$(printf '%s' "$out" | ruby -rjson -e '
+              begin
+                d = JSON.parse(STDIN.read)
+                puts(d["blocking"] || [])
+                  .map { |b| b["code"] }
+                  .join(",")
+              rescue
+                puts ""
+              end' 2>/dev/null)
+            if [ -n "$blocking" ]; then
+              echo "FAIL  $f — blocking: $blocking"
+              # Print the human-readable messages for the failing file.
+              ruby "$LINTER" "$f" 2>/dev/null | grep -E '^BLOCK' || true
+              failed=$((failed + 1))
+            fi
+          done
+
+          echo ""
+          if [ "$failed" -gt 0 ]; then
+            echo "$failed case study file(s) have blocking findings. See above."
+            echo "For taxonomy_invalid: use a canonical value, or add the new value to the"
+            echo "relevant _data/ list (filters.yml / technologies.yml / practices.yml) in a PR."
+            exit 1
+          fi
+          echo "All case studies pass the canonical-quality linter."


### PR DESCRIPTION
## Summary

Phase 5 companion to [skylight-hub #88](https://github.com/skylight-hq/skylight-hub/pull/88). Adds a CI gate that runs the canonical-quality case-study linter against `_projects/*.md` on every PR touching case studies or the `_data/` taxonomy lists. The linter's blocking `taxonomy_invalid` check keeps `tags`/`technologies`/`practices` canonical now that all 64 are migrated.

## Cross-repo wiring + activation

The linter is federation canon in the **private** `skylight-hub` repo; this **public** repo can't read it with the default `GITHUB_TOKEN`. The gate checks out the hub linter via a `HUB_READ_TOKEN` secret (fine-grained PAT, `contents:read` on `skylight-hq/skylight-hub`).

**Until `HUB_READ_TOKEN` is added, the gate skips with a loud warning (non-blocking)** — so this merges cleanly and self-activates once the secret lands. No workflow change needed if the federation later makes hub public or provides a shared token.

## Verification

Ran the linter locally against the full corpus: **all 64 case studies pass every blocking check (0 failures)** — the gate is green on activation.

The authoring path is already protected independently (the marcom case-study interviewer's pickers only offer canonical values); this gate covers hand-edits + taxonomy-list changes.

## Test plan

- [x] Full-corpus local run: 0 blocking findings across 64 case studies
- [ ] CI: the `case-study-lint` job runs, finds no token, skips with warning (green); Netlify build green
- [ ] Activation (admin): add `HUB_READ_TOKEN` secret → gate enforces on next PR