### PR TITLE
Brand 7.5a: switch colors.md to read from _data/brand/ canon

### DIFF
--- a/pages/company/brand/identity/colors.md
+++ b/pages/company/brand/identity/colors.md
@@ -44,7 +44,7 @@ These colors and their meanings help define the way our audience feels about Sky
   </header>
   <div class="grid__image section__img section__img--palette">
     <div class="swatch__container brand-swatch row">
-      {% assign color = site.data.color %}
+      {% assign color = site.data.brand.colors %}
       {% for item in color.primary %}
         <div class="swatch-group col-6 col-md-4">
           <div class="swatch bg-{{ item.token }}"></div>
@@ -66,7 +66,7 @@ The Skylight brand mainly uses blue, gray, and ochre. The blue is the accent col
   </header>
   <div class="grid__image section__img section__img--palette">
     <div class="swatch__container brand-swatch row">
-      {% assign color = site.data.color %}
+      {% assign color = site.data.brand.colors %}
       {% for item in color.secondary %}
         <div class="swatch-group col-6 col-md-4">
           <div class="swatch bg-{{ item.token }}"></div>
@@ -89,7 +89,7 @@ We use the gray colors for text, charts, etc.
 ## Tints
   </header>
   <div class="grid__image section__img p-4 p-md-5">
-    {% assign color = site.data.color %}
+    {% assign color = site.data.brand.colors %}
     <div class="row">
       {% for family in page.families %}
         <div class="swatch__col col-md-6">


### PR DESCRIPTION
## Summary

First and smallest slice of brand-pack Phase 7.5: switch the brand-identity colors page from the legacy `_data/color.yml` to the canonical `_data/brand/colors.yml` (vendored from skylight-hub by `sync-brand-pack.yml`).

**The whole change is one line, three times:** `site.data.color` → `site.data.brand.colors` in `pages/company/brand/identity/colors.md` (lines 47, 69, 92).

## Why this is safe

I verified before editing that both YAML files declare identical top-level keys (`primary`, `secondary`, `blue`, `green`, `red`, `ochre`, `gray`), each a list of `{token, value}` records. The page accesses `color.primary`, `color.secondary`, and `color[family]` where `family ∈ {blue, green, red, ochre, gray}` — all present in both. The rendered HTML should be **byte-identical**.

## Verification

- [x] Both YAMLs have the same shape at the keys colors.md touches (grep-confirmed pre-edit).
- [ ] **Netlify deploy preview = identical to production** (the deciding check — comparing the preview at /company/brand/identity/colors/ against production should be visually indistinguishable).
- [ ] CI green.

## Out of scope (intentional)

- `_data/color.yml` is **not** deleted. Other things may still reference it; that cleanup is a separate PR once a grep-audit confirms colors.md was the only consumer.
- `typography.md`, `logos.md`, `icons.md`, `imagery.md` are pure hardcoded Markdown (no `site.data` refs today) — those are the *real* Phase 7.5 work and ship as separate PRs after this one validates the approach.