### PR TITLE
Brand 7.5b: data-drive the typeface-weight list on typography.md

### DIFF
--- a/pages/company/brand/identity/typography.md
+++ b/pages/company/brand/identity/typography.md
@@ -49,12 +49,14 @@ redirect_from:
   <div class="grid__content" markdown="1">
 [Libre Franklin](https://fonts.google.com/specimen/Libre+Franklin?query=fran&preview.text_type=custom) is the primary typeface with [Roboto Mono](https://fonts.google.com/specimen/Roboto+Mono?query=roboto+mono&preview.text_type=custom) serving as a complementary typeface. Both are available from Google Fonts.
 
-1. Libre Franklin Bold 700
-2. Libre Franklin SemiBold 600
-3. Libre Franklin Medium 500
-4. Libre Franklin Regular 400
-5. Libre Franklin Light 300
-6. Roboto Mono Regular 400
+{%- assign typography = site.data.brand.typography -%}
+{%- assign primary_weights_desc = typography.families.primary.weights | reverse -%}
+{%- for w in primary_weights_desc %}
+1. {{ typography.families.primary.name }} {{ w.name }} {{ w.weight }}
+{%- endfor -%}
+{%- for w in typography.families.monospace.weights %}
+1. {{ typography.families.monospace.name }} {{ w.name }} {{ w.weight }}
+{%- endfor %}
 {: .list--circle }
   </div>
 </div>


### PR DESCRIPTION
## Summary

Replaces the hand-maintained numbered list of typeface weights in typography.md's 'Typefaces' section with a Liquid iteration over canonical `_data/brand/typography.yml`. Output byte-identical to today's page.

**Before** (6 hardcoded list items):
\`\`\`
1. Libre Franklin Bold 700
2. Libre Franklin SemiBold 600
... etc
\`\`\`

**After** (Liquid iteration, primary reversed to keep heaviest-first):
\`\`\`liquid
{% for w in typography.families.primary.weights | reverse %}
1. {{ family.name }} {{ w.name }} {{ w.weight }}
{% endfor %}
{% for w in typography.families.monospace.weights %}
1. {{ family.name }} {{ w.name }} {{ w.weight }}
{% endfor %}
\`\`\`

Kramdown auto-numbers `1.` repeats. Whitespace-control \`{%- -%}\` prevents blank-line insertion that would break the list.

## Intentionally NOT touched

- **Antoine de Saint-Exupéry visual narrative** — editorial design piece, not pure typography data.
- **Usage section's role-assignment list** — maps roles (Pre-headline, Page title, ...) to family+weight combos the YAML doesn't currently encode. Future enrichment to `typography.yml` could enable this.

## Verification

- [ ] **Netlify deploy preview** at \`/company/brand/identity/typography/\` should be visually identical to production for the Typefaces list. The data values come from the same source-of-truth (typography.yml mirrors what was in the prose).
- [ ] CI green.

Cluster B of Phase 7.5. Next: PR C — logos.md (the bigger 318-line page).