### PR TITLE
brand: data-drive Voice qualities on voice_and_tone.md

### DIFF
--- a/pages/company/brand/writing/voice_and_tone.md
+++ b/pages/company/brand/writing/voice_and_tone.md
@@ -18,11 +18,10 @@ redirect_from:
 
 Our voice helps us convey who we are to our audience and is defined by our vision, mission, and values. Having a consistent voice is essential, regardless of who creates the content. Skylight’s voice has five key qualities that reflect both what we say and how we say it:
 
-- Expressive
-- Smart
-- Lighthearted
-- Embracing
-- Worldly
+{%- assign voice_tone = site.data.brand["voice-tone"] -%}
+{%- for q in voice_tone.voice_qualities %}
+- {{ q.name }}
+{%- endfor %}
 
 Working together, these qualities make everything we write sound uniquely Skylight.
 


### PR DESCRIPTION
## Summary
- Swap the hardcoded 5-bullet voice-qualities list for a Liquid loop over \`_data/brand/voice-tone.yml\`'s \`voice_qualities[].name\`
- Byte-identical rendered output (YAML names match the page text exactly)
- Other sections of voice_and_tone.md left as-is — they're prose + content-guide cross-links, no clean data match

## Test plan
- [ ] Netlify deploy preview renders the Voice qualities list identically to production (5 bullets, same order, same names)
- [ ] No Liquid errors in build log