### PR TITLE
sync-brand-pack: vendor icons.yml + imagery.yml from hub

### DIFF
--- a/.github/workflows/sync-brand-pack.yml
+++ b/.github/workflows/sync-brand-pack.yml
@@ -42,7 +42,7 @@ jobs:
       SOURCE_REPO: skylight-hq/skylight-hub
       DEST_DIR: _data/brand
       SOURCE_DIR: plugins/skylight-brand-pack/config
-      FILES: colors.yml typography.yml logo-rules.yml voice-tone.yml brand-narrative.yml illustration.yml customer-brand-rules.yml
+      FILES: colors.yml typography.yml logo-rules.yml voice-tone.yml brand-narrative.yml illustration.yml customer-brand-rules.yml icons.yml imagery.yml
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

brand-pack 0.5.0 (skylight-hub #103) added `config/icons.yml` + `config/imagery.yml`. This adds both to the `sync-brand-pack.yml` `FILES:` list so they vendor into `_data/brand/` on the next sync (Monday cron or manual dispatch).

## Effect
- Next sync fetches the two new YAMLs and opens the usual `sync/brand-pack` PR with them
- Once in `_data/brand/`, the website's `icons.md` + `imagery.md` pages become Phase 7.5 data-driving candidates (separate follow-on)

## Test plan
- [ ] Manually dispatch `sync-brand-pack` after merge; confirm icons.yml + imagery.yml appear in the resulting sync PR with refreshed headers