### PR TITLE
brand: data-drive icons + imagery pages (Phase 7.5)

### DIFF
--- a/pages/company/brand/identity/icons.md
+++ b/pages/company/brand/identity/icons.md
@@ -59,6 +59,6 @@ We use our standard icon as an avatar in our different online spaces and social 
   </div>
   </div>
   <div class="grid__content" markdown="1">
-Use the standard and grayscale icon on the top for light backgrounds and the inverse standard and grayscale icon on the bottom for dark (including the darker blue).
+{{ site.data.brand.icons.variants_usage_rule | strip }}
   </div>
 </div>

--- a/pages/company/brand/identity/imagery.md
+++ b/pages/company/brand/identity/imagery.md
@@ -50,11 +50,10 @@ Facial expressions, clothing, and hair/makeup should look natural (not over-the-
 
 Every image should tell a story. There are a few tricks we can use to make sure your message comes across to viewers:
 
-- Figure out what you're trying to say with this photo
-- Capture all relevant objects, people, and background
-- Focus your image on people in action, facial expressions, and body language
-- Consider the composition of your image
-- Take a moment to remove any distractions from the scene
+{%- assign imagery = site.data.brand.imagery -%}
+{%- for trick in imagery.photography.story_tricks.rules %}
+- {{ trick }}
+{%- endfor %}
 </div>
 </div>
 
@@ -73,12 +72,6 @@ Every image should tell a story. There are a few tricks we can use to make sure 
     </div>
   </div>
   <div class="grid__content" markdown="1">
-We aim to take authentic portraits of people.
-
-Use a shallow depth of field in an outdoor setting.
-
-When possible, set up images to include an element of blue (in clothing or surroundings).
-
-The photo should be edited using a realistic color balance.
+{{ site.data.brand.imagery.portraits.description | strip }}
   </div>
 </div>


### PR DESCRIPTION
## Summary

Completes Phase 7.5 for `icons.md` + `imagery.md`, now that their canon landed in `_data/brand/` (icons.yml + imagery.yml from brand-pack 0.5.0, synced via #555/#556).

**Data-driven (expected byte-identical):**
- `icons.md` Variants usage text → `{{ site.data.brand.icons.variants_usage_rule }}` (verbatim-correct after hub #106)
- `imagery.md` Photography 5-bullet list → Liquid loop (same pattern as the shipped voice-qualities list)
- `imagery.md` Portraits prose → `{{ imagery.portraits.description }}`

**Left hardcoded (not clean 1:1 — see commit msg):** icons Standard-icon body (frontmatter/body split), imagery Photography goals prose (paragraph-join), Illustration pointer section.

## Test plan — ⚠️ verify before merge
- [ ] **Netlify deploy preview**: `/company/brand/identity/icons/` and `/company/brand/identity/imagery/` render **identical** to production (Variants text, Photography bullets, Portraits paragraphs). Local Jekyll build is unavailable in my env, so the preview is the gate.
- [ ] No raw `{{ }}`/`{%- %}` artifacts; no collapsed/extra paragraphs.