### PR TITLE
Add asset-manifest pre-commit check (no author-identity guard)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Git hook scripts must keep LF line endings — CRLF breaks the bash shebang
+# when a hook is run on a clone configured with core.autocrlf=true.
+scripts/hooks/pre-commit text eol=lf
+scripts/install-hooks.sh text eol=lf

--- a/_config.yml
+++ b/_config.yml
@@ -112,6 +112,7 @@ exclude:
   - npm-debug.log
   - docs
   - lighthouse
+  - scripts
 
 # Plugins & gems
 plugins:

--- a/scripts/hooks/README.md
+++ b/scripts/hooks/README.md
@@ -1,0 +1,31 @@
+---
+title: Git hooks
+status: active
+owner: Federation Steward
+---
+
+# Git hooks
+
+Per-clone git hook, **copied (in part) from the [skylight-hub hooks canon](https://github.com/skylight-hq/skylight-hub/tree/main/scripts/hooks)**. `.git/hooks/` isn't tracked by git, so the hook lives here and `scripts/install-hooks.sh` copies it into `.git/hooks/` of each clone.
+
+## What's here
+
+| File | Role |
+|---|---|
+| `pre-commit` | Runs the federation asset-manifest validator on any staged `assets-manifest.yml` / `image-library.yml` (warn-only; self-skips until this repo bootstraps the validator). |
+
+**This repo intentionally omits the hub's author-identity guard** (`allowed-authors.txt` + `prepare-commit-msg`): skylight.digital has many contributors, so an author allowlist isn't appropriate here. Only the asset-manifest check is mirrored, for forward-readiness once the repo bootstraps the federation asset registry.
+
+## Installing
+
+After a fresh clone (or `git worktree add`):
+
+```bash
+./scripts/install-hooks.sh
+```
+
+Idempotent — re-run any time the canonical hook changes.
+
+## Canonical source
+
+Copied from `skylight-hub`. See the [hub README](https://github.com/skylight-hq/skylight-hub/blob/main/scripts/hooks/README.md) for the full asset-manifest-check rationale and the `ASSET_MANIFEST_STRICT=1` strict toggle.

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Asset-manifest pre-commit check for this clone.
+#
+# Runs scripts/check_asset_manifests.rb on any staged asset manifest
+# (federation asset registry Phase A.2.4). WARN-ONLY during bootstrap; never
+# blocks unless ASSET_MANIFEST_STRICT=1. Self-skips when the validator isn't
+# present (repo not yet bootstrapped for the asset registry).
+#
+# This is the asset-manifest portion of the skylight-hub hooks canon. This
+# repo intentionally omits the hub's author-identity guard (it has many
+# contributors, so an allowlist isn't appropriate here).
+#
+# Install per-clone via `scripts/install-hooks.sh` (or copy to
+# .git/hooks/pre-commit + chmod +x).
+
+set -e
+
+repo_root=$(git rev-parse --show-toplevel)
+
+# Warn-only during bootstrap: surface schema/vocab findings on staged manifests
+# but never block the commit. Set ASSET_MANIFEST_STRICT=1 (Phase F.5) to make
+# this hook block locally too — that mode adds --warn-as-error and propagates
+# the validator's non-zero exit.
+strict="${ASSET_MANIFEST_STRICT:-0}"
+
+# Staged manifests (added/copied/modified), matching the validator's discovery
+# globs (assets-manifest.yml + image-library.yml). `|| true` keeps a no-match
+# grep from tripping `set -e`.
+staged_manifests=$(git diff --cached --name-only --diff-filter=ACM \
+  | grep -E '(^|/)(assets-manifest|image-library)\.yml$' || true)
+
+if [ -n "$staged_manifests" ]; then
+  validator="$repo_root/scripts/check_asset_manifests.rb"
+  if [ ! -f "$validator" ]; then
+    # Portable across the federation: self-skips until this repo bootstraps the
+    # asset registry (validator/schema/vocab), then auto-activates.
+    echo "WARN: $validator not present; skipping asset-manifest check (repo not yet bootstrapped for the asset registry)." >&2
+  elif ! command -v ruby >/dev/null 2>&1; then
+    echo "WARN: ruby not found; skipping asset-manifest check." >&2
+  else
+    echo "Validating staged asset manifest(s):" >&2
+    rc=0
+    while IFS= read -r manifest; do
+      [ -n "$manifest" ] || continue
+      if [ "$strict" = "1" ]; then
+        ruby "$validator" --warn-as-error --manifest "$manifest" || rc=$?
+      else
+        ruby "$validator" --manifest "$manifest" || rc=$?
+      fi
+    done <<EOF
+$staged_manifests
+EOF
+
+    if [ "$rc" -ne 0 ]; then
+      if [ "$strict" = "1" ]; then
+        echo "" >&2
+        echo "ERROR: asset-manifest validation failed (strict mode)." >&2
+        echo "Fix the findings above, or unset ASSET_MANIFEST_STRICT to bypass during bootstrap." >&2
+        exit 1
+      fi
+      echo "" >&2
+      echo "WARN: asset-manifest validation found issues (warn-only during bootstrap; commit allowed)." >&2
+    fi
+  fi
+fi

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Install scripts/hooks/* into .git/hooks/ of the current clone.
+#
+# Run after a fresh clone (or `git worktree add`):
+#   ./scripts/install-hooks.sh
+#
+# Idempotent — overwrites existing .git/hooks/ hook scripts with the canonical
+# copies. Skips docs + data files (README.md, *.txt, dotfiles) — only
+# executable hook scripts get installed.
+#
+# Copied from skylight-hub canon; this repo carries only the asset-manifest
+# pre-commit check (no author-identity guard). See scripts/hooks/README.md.
+
+set -e
+
+repo_root=$(git rev-parse --show-toplevel)
+src_dir="$repo_root/scripts/hooks"
+# Let git resolve the hooks dir so this works in linked worktrees too: there
+# $repo_root/.git is a file (not a dir) and hooks live in the shared common
+# git dir. `git rev-parse --git-path hooks` returns the right path in both a
+# normal clone and a worktree.
+dest_dir=$(git rev-parse --git-path hooks)
+
+[ -d "$src_dir" ]  || { echo "ERROR: $src_dir not found." >&2; exit 1; }
+[ -d "$dest_dir" ] || { echo "ERROR: $dest_dir not found. Not a git repo?" >&2; exit 1; }
+
+installed=0
+for src in "$src_dir"/*; do
+  [ -f "$src" ] || continue
+  name=$(basename "$src")
+  case "$name" in
+    *.md|*.txt|.*) continue ;;  # docs + data, not hooks
+  esac
+  dest="$dest_dir/$name"
+  cp "$src" "$dest"
+  chmod +x "$dest"
+  echo "installed: $dest"
+  installed=$((installed + 1))
+done
+
+if [ "$installed" -eq 0 ]; then
+  echo "WARN: no hooks installed (scripts/hooks/ had no hook scripts?)" >&2
+  exit 0
+fi
+echo ""
+echo "$installed hook(s) installed. Asset-manifest check is active."


### PR DESCRIPTION
Mirrors the **asset-manifest portion** of the skylight-hub git hooks canon — part of [federation asset registry Phase A.2.4](https://github.com/skylight-hq/skylight-hub/pull/114).

## What this adds
- `scripts/hooks/pre-commit` — warn-only asset-manifest check on staged `assets-manifest.yml` / `image-library.yml`. **Self-skips** until this repo bootstraps the validator (inert today), then auto-activates. `ASSET_MANIFEST_STRICT=1` promotes to blocking (Phase F.5).
- `scripts/install-hooks.sh` — per-clone installer (worktree-safe).
- `_config.yml` — excludes `scripts/` from the Jekyll build (internal tooling, not site content).
- `.gitattributes` — pins the hook scripts to LF.

**The hub's author-identity guard is intentionally omitted** — skylight.digital has many contributors, so an author allowlist isn't appropriate here. Only the asset-manifest check is mirrored, for forward-readiness.

## Install
```bash
./scripts/install-hooks.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
