### PR TITLE
Phase C.1: asset registry on skylight.digital — catalog img/brand (113)

### DIFF
--- a/.github/workflows/asset-manifests.yml
+++ b/.github/workflows/asset-manifests.yml
@@ -1,0 +1,34 @@
+# Federation asset registry — per-repo manifest validation (Phase C).
+# Mirrors skylight-hub's validate-asset-manifests job. Validates every
+# asset manifest in this repo against the canon schema + vocab copied from
+# the hub (standards/asset-*.yml). See standards/asset-manifests via the hub.
+name: Asset manifests
+
+on:
+  pull_request:
+    paths:
+      - '**/assets-manifest.yml'
+      - '**/image-library.yml'
+      - 'scripts/check_asset_manifests.rb'
+      - 'standards/asset-manifest-schema.yml'
+      - 'standards/asset-vocabulary.yml'
+  push:
+    branches: [master]
+    paths:
+      - '**/assets-manifest.yml'
+      - '**/image-library.yml'
+      - 'scripts/check_asset_manifests.rb'
+      - 'standards/asset-manifest-schema.yml'
+      - 'standards/asset-vocabulary.yml'
+
+jobs:
+  validate-asset-manifests:
+    name: Validate asset manifests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+      - name: Validate every asset manifest in the repo
+        run: ruby scripts/check_asset_manifests.rb

--- a/_config.yml
+++ b/_config.yml
@@ -113,6 +113,7 @@ exclude:
   - docs
   - lighthouse
   - scripts
+  - standards
 
 # Plugins & gems
 plugins:

--- a/img/brand/assets-manifest.yml
+++ b/img/brand/assets-manifest.yml
@@ -1,0 +1,1648 @@
+# Federation asset manifest -- skylight.digital img/brand (Phase C.1).
+#
+# Catalogs the Skylight brand identity asset set served on skylight.digital's
+# brand-guide pages. All entries are Skylight's own marks/illustrations on the
+# public site -> permissions: skylight-owned, classification: public.
+# ids are path-based (unique within the repo + distinct from the hub's
+# brand-pack manifest, which vendors a subset of these same logos).
+# Schema: standards/asset-manifest-schema.yml; validate: ruby scripts/check_asset_manifests.rb
+- id: hero-identity-colors
+  path: hero/identity/colors.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide page-header illustration: Identity Colors'
+  description: Page-header (hero) illustration for the brand-guide Identity Colors
+    page on skylight.digital.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: hero-identity-icons
+  path: hero/identity/icons.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide page-header illustration: Identity Icons'
+  description: Page-header (hero) illustration for the brand-guide Identity Icons
+    page on skylight.digital.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: hero-identity-imagery
+  path: hero/identity/imagery.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide page-header illustration: Identity Imagery'
+  description: Page-header (hero) illustration for the brand-guide Identity Imagery
+    page on skylight.digital.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: hero-identity-logos
+  path: hero/identity/logos.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide page-header illustration: Identity Logos'
+  description: Page-header (hero) illustration for the brand-guide Identity Logos
+    page on skylight.digital.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: hero-identity-typography
+  path: hero/identity/typography.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide page-header illustration: Identity Typography'
+  description: Page-header (hero) illustration for the brand-guide Identity Typography
+    page on skylight.digital.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: hero-illustration-illustration-types
+  path: hero/illustration/illustration-types.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide page-header illustration: Illustration Illustration Types'
+  description: Page-header (hero) illustration for the brand-guide Illustration Illustration
+    Types page on skylight.digital.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: hero-illustration-principles
+  path: hero/illustration/principles.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide page-header illustration: Illustration Principles'
+  description: Page-header (hero) illustration for the brand-guide Illustration Principles
+    page on skylight.digital.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: hero-illustration-visual-style
+  path: hero/illustration/visual-style.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide page-header illustration: Illustration Visual Style'
+  description: Page-header (hero) illustration for the brand-guide Illustration Visual
+    Style page on skylight.digital.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: hero-landing
+  path: hero/landing.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide page-header illustration: Landing'
+  description: Page-header (hero) illustration for the brand-guide Landing page on
+    skylight.digital.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: hero-outreach-design-guidance
+  path: hero/outreach/design-guidance.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide page-header illustration: Outreach Design Guidance'
+  description: Page-header (hero) illustration for the brand-guide Outreach Design
+    Guidance page on skylight.digital.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: hero-outreach-outreach-types
+  path: hero/outreach/outreach-types.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide page-header illustration: Outreach Outreach Types'
+  description: Page-header (hero) illustration for the brand-guide Outreach Outreach
+    Types page on skylight.digital.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: hero-resources-downloads
+  path: hero/resources/downloads.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide page-header illustration: Resources Downloads'
+  description: Page-header (hero) illustration for the brand-guide Resources Downloads
+    page on skylight.digital.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: hero-resources-emoji
+  path: hero/resources/emoji.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide page-header illustration: Resources Emoji'
+  description: Page-header (hero) illustration for the brand-guide Resources Emoji
+    page on skylight.digital.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: hero-resources-templates
+  path: hero/resources/templates.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide page-header illustration: Resources Templates'
+  description: Page-header (hero) illustration for the brand-guide Resources Templates
+    page on skylight.digital.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: hero-writing-brand-narrative
+  path: hero/writing/brand-narrative.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide page-header illustration: Writing Brand Narrative'
+  description: Page-header (hero) illustration for the brand-guide Writing Brand Narrative
+    page on skylight.digital.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: hero-writing-style
+  path: hero/writing/style.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide page-header illustration: Writing Style'
+  description: Page-header (hero) illustration for the brand-guide Writing Style page
+    on skylight.digital.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: hero-writing-voice-and-tone
+  path: hero/writing/voice-and-tone.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide page-header illustration: Writing Voice And Tone'
+  description: Page-header (hero) illustration for the brand-guide Writing Voice And
+    Tone page on skylight.digital.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-assets-icon-avatar-svg-halo-grayscale-inverse
+  path: identity/assets/icon/avatar/svg/halo-grayscale-inverse.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: Skylight halo icon in grayscale, reversed for dark backgrounds
+  description: Grayscale Skylight halo logomark for dark backgrounds.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-assets-icon-avatar-svg-halo-grayscale
+  path: identity/assets/icon/avatar/svg/halo-grayscale.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: Skylight halo icon in grayscale, for light backgrounds
+  description: Grayscale Skylight halo logomark for light backgrounds.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-assets-icon-avatar-svg-halo-inverse
+  path: identity/assets/icon/avatar/svg/halo-inverse.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: Skylight halo icon, reversed for dark backgrounds
+  description: The Skylight halo logomark (color) in its dark-background inverse treatment.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-assets-icon-avatar-svg-halo
+  path: identity/assets/icon/avatar/svg/halo.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight halo icon: a circular mark in the four brand colors'
+  description: The Skylight halo logomark alone, a circular form in the four brand
+    colors; used as a standalone icon. Full color, light backgrounds.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-assets-logos-svg-skylight-bar-bottom-inverse
+  path: identity/assets/logos/svg/skylight-bar-bottom-inverse.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo variant: Skylight Bar Bottom Inverse'
+  description: Skylight logo variant (Skylight Bar Bottom Inverse) from the brand
+    identity asset set.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-assets-logos-svg-skylight-bar-bottom
+  path: identity/assets/logos/svg/skylight-bar-bottom.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo variant: Skylight Bar Bottom'
+  description: Skylight logo variant (Skylight Bar Bottom) from the brand identity
+    asset set.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-assets-logos-svg-skylight-bar-top-inverse
+  path: identity/assets/logos/svg/skylight-bar-top-inverse.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo variant: Skylight Bar Top Inverse'
+  description: Skylight logo variant (Skylight Bar Top Inverse) from the brand identity
+    asset set.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-assets-logos-svg-skylight-bar-top
+  path: identity/assets/logos/svg/skylight-bar-top.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo variant: Skylight Bar Top'
+  description: Skylight logo variant (Skylight Bar Top) from the brand identity asset
+    set.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-assets-logos-svg-skylight-grayscale-inverse
+  path: identity/assets/logos/svg/skylight-grayscale-inverse.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: Skylight logo in grayscale, reversed for dark backgrounds
+  description: Grayscale Skylight logo for dark backgrounds; used only when color
+    is unavailable.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-assets-logos-svg-skylight-grayscale
+  path: identity/assets/logos/svg/skylight-grayscale.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: Skylight logo in grayscale, for light backgrounds
+  description: Grayscale Skylight logo for light backgrounds; used only when color
+    is unavailable.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-assets-logos-svg-skylight-hubzone
+  path: identity/assets/logos/svg/skylight-hubzone.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: Skylight logo paired with the HUBZone certification mark
+  description: Skylight logo with the SBA HUBZone certification mark, for government-contracting
+    surfaces.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-assets-logos-svg-skylight-inverse
+  path: identity/assets/logos/svg/skylight-inverse.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: Skylight color logo reversed for dark backgrounds
+  description: Standard Skylight logo in its dark-background inverse treatment.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-assets-logos-svg-skylight-logo
+  path: identity/assets/logos/svg/skylight-logo.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo: the wordmark with the multicolor halo, full color'
+  description: Standard Skylight logo (wordmark + multicolor halo) for light backgrounds;
+    the canonical brand mark.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-assets-logos-svg-skylight-one-color-inverse
+  path: identity/assets/logos/svg/skylight-one-color-inverse.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: Single-color Skylight logo, reversed for dark backgrounds
+  description: One-color Skylight logo for single-color reproduction on dark backgrounds.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-assets-logos-svg-skylight-one-color
+  path: identity/assets/logos/svg/skylight-one-color.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: Single-color Skylight logo, for light backgrounds
+  description: One-color Skylight logo for single-color reproduction (embroidery,
+    etched signage, single-color print) on light backgrounds.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-colors-brand-colors
+  path: identity/colors/brand-colors.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand color sample: Brand Colors'
+  description: Brand color palette sample/swatch (Brand Colors).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-colors-primary-palette
+  path: identity/colors/primary-palette.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand color sample: Primary Palette'
+  description: Brand color palette sample/swatch (Primary Palette).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-colors-secondary-palette
+  path: identity/colors/secondary-palette.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand color sample: Secondary Palette'
+  description: Brand color palette sample/swatch (Secondary Palette).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-colors-tints
+  path: identity/colors/tints.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand color sample: Tints'
+  description: Brand color palette sample/swatch (Tints).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-colors-tints-2
+  path: identity/colors/tints.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand color sample: Tints'
+  description: Brand color palette sample/swatch (Tints).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-icons-avatars
+  path: identity/icons/avatars.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight brand icon: Avatars'
+  description: Brand icon from the identity icon set (Avatars).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-icons-avatars-2
+  path: identity/icons/avatars.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight brand icon: Avatars'
+  description: Brand icon from the identity icon set (Avatars).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-icons-intro
+  path: identity/icons/intro.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight brand icon: Intro'
+  description: Brand icon from the identity icon set (Intro).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-icons-variants
+  path: identity/icons/variants.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight brand icon: Variants'
+  description: Brand icon from the identity icon set (Variants).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-icons-variants-2
+  path: identity/icons/variants.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight brand icon: Variants'
+  description: Brand icon from the identity icon set (Variants).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-imagery-illustration
+  path: identity/imagery/illustration.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand imagery example: Illustration'
+  description: Photography / imagery example from the brand identity guide (Illustration).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-imagery-photography-2
+  path: identity/imagery/photography-2.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand imagery example: Photography 2'
+  description: Photography / imagery example from the brand identity guide (Photography
+    2).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-imagery-photography
+  path: identity/imagery/photography.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand imagery example: Photography'
+  description: Photography / imagery example from the brand identity guide (Photography).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-imagery-portraits
+  path: identity/imagery/portraits.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand imagery example: Portraits'
+  description: Photography / imagery example from the brand identity guide (Portraits).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-behind-the-design-halo
+  path: identity/logos/behind-the-design--halo.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo variant: Behind The Design Halo'
+  description: Skylight logo variant (Behind The Design Halo) from the brand identity
+    asset set.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-behind-the-design-type
+  path: identity/logos/behind-the-design--type.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo variant: Behind The Design Type'
+  description: Skylight logo variant (Behind The Design Type) from the brand identity
+    asset set.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-general-positioning
+  path: identity/logos/general-positioning.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo variant: General Positioning'
+  description: Skylight logo variant (General Positioning) from the brand identity
+    asset set.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-list-indicator-1
+  path: identity/logos/list-indicator--1.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo variant: List Indicator 1'
+  description: Skylight logo variant (List Indicator 1) from the brand identity asset
+    set.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-list-indicator-2
+  path: identity/logos/list-indicator--2.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo variant: List Indicator 2'
+  description: Skylight logo variant (List Indicator 2) from the brand identity asset
+    set.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-list-indicator-3
+  path: identity/logos/list-indicator--3.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo variant: List Indicator 3'
+  description: Skylight logo variant (List Indicator 3) from the brand identity asset
+    set.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-logotype
+  path: identity/logos/logotype.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo variant: Logotype'
+  description: Skylight logo variant (Logotype) from the brand identity asset set.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-minimum-sizes
+  path: identity/logos/minimum-sizes.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo variant: Minimum Sizes'
+  description: Skylight logo variant (Minimum Sizes) from the brand identity asset
+    set.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-positioning-bottom-left
+  path: identity/logos/positioning/bottom-left.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo positioning diagram: Bottom Left'
+  description: Brand-guide logo positioning / clear-space diagram (Bottom Left).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-positioning-bottom-right
+  path: identity/logos/positioning/bottom-right.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo positioning diagram: Bottom Right'
+  description: Brand-guide logo positioning / clear-space diagram (Bottom Right).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-positioning-top-left
+  path: identity/logos/positioning/top-left.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo positioning diagram: Top Left'
+  description: Brand-guide logo positioning / clear-space diagram (Top Left).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-positioning-top-right
+  path: identity/logos/positioning/top-right.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo positioning diagram: Top Right'
+  description: Brand-guide logo positioning / clear-space diagram (Top Right).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-rotation
+  path: identity/logos/rotation.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo variant: Rotation'
+  description: Skylight logo variant (Rotation) from the brand identity asset set.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-spacing
+  path: identity/logos/spacing.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo variant: Spacing'
+  description: Skylight logo variant (Spacing) from the brand identity asset set.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-things-to-avoid
+  path: identity/logos/things-to-avoid.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo variant: Things To Avoid'
+  description: Skylight logo variant (Things To Avoid) from the brand identity asset
+    set.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-things-to-avoid-bg-image
+  path: identity/logos/things-to-avoid/bg-image.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo misuse example: Bg Image'
+  description: Brand-guide 'things to avoid' example showing an incorrect logo treatment
+    (Bg Image).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-things-to-avoid-diagonal
+  path: identity/logos/things-to-avoid/diagonal.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo misuse example: Diagonal'
+  description: Brand-guide 'things to avoid' example showing an incorrect logo treatment
+    (Diagonal).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-things-to-avoid-image-type
+  path: identity/logos/things-to-avoid/image-type.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo misuse example: Image Type'
+  description: Brand-guide 'things to avoid' example showing an incorrect logo treatment
+    (Image Type).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-things-to-avoid-mono-type
+  path: identity/logos/things-to-avoid/mono-type.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo misuse example: Mono Type'
+  description: Brand-guide 'things to avoid' example showing an incorrect logo treatment
+    (Mono Type).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-things-to-avoid-outline-type
+  path: identity/logos/things-to-avoid/outline-type.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo misuse example: Outline Type'
+  description: Brand-guide 'things to avoid' example showing an incorrect logo treatment
+    (Outline Type).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-things-to-avoid-red-type
+  path: identity/logos/things-to-avoid/red-type.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo misuse example: Red Type'
+  description: Brand-guide 'things to avoid' example showing an incorrect logo treatment
+    (Red Type).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-things-to-avoid-spaced-type
+  path: identity/logos/things-to-avoid/spaced-type.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo misuse example: Spaced Type'
+  description: Brand-guide 'things to avoid' example showing an incorrect logo treatment
+    (Spaced Type).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-logos-things-to-avoid-squished-type
+  path: identity/logos/things-to-avoid/squished-type.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: logo
+  themes:
+  - brand
+  tags: []
+  alt: 'Skylight logo misuse example: Squished Type'
+  description: Brand-guide 'things to avoid' example showing an incorrect logo treatment
+    (Squished Type).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-typography-step-1
+  path: identity/typography/step-1.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand typography specimen: Step 1'
+  description: Typography specimen from the brand identity guide (Step 1).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-typography-step-2
+  path: identity/typography/step-2.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand typography specimen: Step 2'
+  description: Typography specimen from the brand identity guide (Step 2).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-typography-step-3
+  path: identity/typography/step-3.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand typography specimen: Step 3'
+  description: Typography specimen from the brand identity guide (Step 3).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-typography-step-4
+  path: identity/typography/step-4.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand typography specimen: Step 4'
+  description: Typography specimen from the brand identity guide (Step 4).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-typography-step-5
+  path: identity/typography/step-5.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand typography specimen: Step 5'
+  description: Typography specimen from the brand identity guide (Step 5).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-typography-step-6
+  path: identity/typography/step-6.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand typography specimen: Step 6'
+  description: Typography specimen from the brand identity guide (Step 6).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-typography-typefaces
+  path: identity/typography/typefaces.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand typography specimen: Typefaces'
+  description: Typography specimen from the brand identity guide (Typefaces).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-typography-typefaces-2
+  path: identity/typography/typefaces.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand typography specimen: Typefaces'
+  description: Typography specimen from the brand identity guide (Typefaces).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-typography-usage
+  path: identity/typography/usage.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand typography specimen: Usage'
+  description: Typography specimen from the brand identity guide (Usage).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: identity-typography-usage-2
+  path: identity/typography/usage.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand typography specimen: Usage'
+  description: Typography specimen from the brand identity guide (Usage).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: illustration-featured-post
+  path: illustration/featured-post.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand illustration example: Featured Post'
+  description: Illustration example from the brand-guide illustration section (Featured
+    Post).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: illustration-floating-1
+  path: illustration/floating-1.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand illustration example: Floating 1'
+  description: Illustration example from the brand-guide illustration section (Floating
+    1).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: illustration-floating-2
+  path: illustration/floating-2.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand illustration example: Floating 2'
+  description: Illustration example from the brand-guide illustration section (Floating
+    2).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: illustration-general-guidance
+  path: illustration/general-guidance.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand illustration example: General Guidance'
+  description: Illustration example from the brand-guide illustration section (General
+    Guidance).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: illustration-graphic-elements
+  path: illustration/graphic-elements.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand illustration example: Graphic Elements'
+  description: Illustration example from the brand-guide illustration section (Graphic
+    Elements).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: illustration-heroes-contact-us-hero
+  path: illustration/heroes/contact-us-hero.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand illustration example: Contact Us Hero'
+  description: Illustration example from the brand-guide illustration section (Contact
+    Us Hero).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: illustration-heroes-service-design-hero
+  path: illustration/heroes/service-design-hero.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand illustration example: Service Design Hero'
+  description: Illustration example from the brand-guide illustration section (Service
+    Design Hero).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: illustration-heroes-talks-hero
+  path: illustration/heroes/talks-hero.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand illustration example: Talks Hero'
+  description: Illustration example from the brand-guide illustration section (Talks
+    Hero).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: illustration-palette
+  path: illustration/palette.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand illustration example: Palette'
+  description: Illustration example from the brand-guide illustration section (Palette).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: illustration-portraits
+  path: illustration/portraits.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand illustration example: Portraits'
+  description: Illustration example from the brand-guide illustration section (Portraits).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: illustration-primary-colors
+  path: illustration/primary-colors.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand illustration example: Primary Colors'
+  description: Illustration example from the brand-guide illustration section (Primary
+    Colors).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: illustration-skin-and-hair
+  path: illustration/skin-and-hair.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand illustration example: Skin And Hair'
+  description: Illustration example from the brand-guide illustration section (Skin
+    And Hair).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: illustration-style-1
+  path: illustration/style-1.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand illustration example: Style 1'
+  description: Illustration example from the brand-guide illustration section (Style
+    1).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: illustration-style-2
+  path: illustration/style-2.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand illustration example: Style 2'
+  description: Illustration example from the brand-guide illustration section (Style
+    2).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: landing-identity
+  path: landing/identity.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide landing illustration: Identity'
+  description: Illustration from the brand-guide landing page (Identity).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: landing-illustration
+  path: landing/illustration.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide landing illustration: Illustration'
+  description: Illustration from the brand-guide landing page (Illustration).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: landing-outreach
+  path: landing/outreach.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide landing illustration: Outreach'
+  description: Illustration from the brand-guide landing page (Outreach).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: landing-resources
+  path: landing/resources.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide landing illustration: Resources'
+  description: Illustration from the brand-guide landing page (Resources).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: landing-writing
+  path: landing/writing.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand-guide landing illustration: Writing'
+  description: Illustration from the brand-guide landing page (Writing).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: outreach-business-card
+  path: outreach/business-card.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Outreach design example: Business Card'
+  description: Outreach / swag design example from the brand guide (Business Card).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: outreach-email-signature
+  path: outreach/email-signature.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Outreach design example: Email Signature'
+  description: Outreach / swag design example from the brand guide (Email Signature).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: outreach-external-promotion-material
+  path: outreach/external-promotion-material.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Outreach design example: External Promotion Material'
+  description: Outreach / swag design example from the brand guide (External Promotion
+    Material).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: outreach-guidelines
+  path: outreach/guidelines.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Outreach design example: Guidelines'
+  description: Outreach / swag design example from the brand guide (Guidelines).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: outreach-hero
+  path: outreach/hero.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Outreach design example: Hero'
+  description: Outreach / swag design example from the brand guide (Hero).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: outreach-online-ad
+  path: outreach/online-ad.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Outreach design example: Online Ad'
+  description: Outreach / swag design example from the brand guide (Online Ad).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: outreach-personal-growth-share-outs-flyer
+  path: outreach/personal-growth-share-outs-flyer.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Outreach design example: Personal Growth Share Outs Flyer'
+  description: Outreach / swag design example from the brand guide (Personal Growth
+    Share Outs Flyer).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: outreach-swag
+  path: outreach/swag.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Outreach design example: Swag'
+  description: Outreach / swag design example from the brand guide (Swag).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: outreach-swag-bottle
+  path: outreach/swag/bottle.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Outreach design example: Bottle'
+  description: Outreach / swag design example from the brand guide (Bottle).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: outreach-swag-hoodie
+  path: outreach/swag/hoodie.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Outreach design example: Hoodie'
+  description: Outreach / swag design example from the brand guide (Hoodie).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: outreach-swag-shirt
+  path: outreach/swag/shirt.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Outreach design example: Shirt'
+  description: Outreach / swag design example from the brand guide (Shirt).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: outreach-swag-sweatshirt
+  path: outreach/swag/sweatshirt.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: photo
+  themes:
+  - brand
+  tags: []
+  alt: 'Outreach design example: Sweatshirt'
+  description: Outreach / swag design example from the brand guide (Sweatshirt).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: resources-assets-skylight-heart
+  path: resources/assets/skylight-heart.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand resources graphic: Skylight Heart'
+  description: Graphic from the brand-guide resources section (Skylight Heart).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: resources-emoji
+  path: resources/emoji.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand resources graphic: Emoji'
+  description: Graphic from the brand-guide resources section (Emoji).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: resources-skylight-heart
+  path: resources/skylight-heart.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - brand
+  tags: []
+  alt: 'Brand resources graphic: Skylight Heart'
+  description: Graphic from the brand-guide resources section (Skylight Heart).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false

--- a/img/brand/assets-manifest.yml
+++ b/img/brand/assets-manifest.yml
@@ -326,9 +326,9 @@
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo variant: Skylight Bar Bottom Inverse'
-  description: Skylight logo variant (Skylight Bar Bottom Inverse) from the brand
-    identity asset set.
+  alt: 'Skylight logo variant: Bar Bottom Inverse'
+  description: Skylight logo variant (Bar Bottom Inverse) from the brand identity
+    asset set.
   permissions: skylight-owned
   classification: public
   archived: false
@@ -341,9 +341,8 @@
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo variant: Skylight Bar Bottom'
-  description: Skylight logo variant (Skylight Bar Bottom) from the brand identity
-    asset set.
+  alt: 'Skylight logo variant: Bar Bottom'
+  description: Skylight logo variant (Bar Bottom) from the brand identity asset set.
   permissions: skylight-owned
   classification: public
   archived: false
@@ -356,9 +355,9 @@
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo variant: Skylight Bar Top Inverse'
-  description: Skylight logo variant (Skylight Bar Top Inverse) from the brand identity
-    asset set.
+  alt: 'Skylight logo variant: Bar Top Inverse'
+  description: Skylight logo variant (Bar Top Inverse) from the brand identity asset
+    set.
   permissions: skylight-owned
   classification: public
   archived: false
@@ -371,9 +370,8 @@
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo variant: Skylight Bar Top'
-  description: Skylight logo variant (Skylight Bar Top) from the brand identity asset
-    set.
+  alt: 'Skylight logo variant: Bar Top'
+  description: Skylight logo variant (Bar Top) from the brand identity asset set.
   permissions: skylight-owned
   classification: public
   archived: false
@@ -499,7 +497,7 @@
   path: identity/colors/primary-palette.jpg
   repo: skylight.digital
   date: '2026-03-26'
-  type: photo
+  type: diagram
   themes:
   - brand
   tags: []
@@ -513,7 +511,7 @@
   path: identity/colors/secondary-palette.jpg
   repo: skylight.digital
   date: '2026-03-26'
-  type: photo
+  type: diagram
   themes:
   - brand
   tags: []
@@ -527,7 +525,7 @@
   path: identity/colors/tints.jpg
   repo: skylight.digital
   date: '2026-03-26'
-  type: photo
+  type: diagram
   themes:
   - brand
   tags: []
@@ -555,7 +553,7 @@
   path: identity/icons/avatars.jpg
   repo: skylight.digital
   date: '2026-03-26'
-  type: photo
+  type: illustration
   themes:
   - brand
   tags: []
@@ -597,7 +595,7 @@
   path: identity/icons/variants.jpg
   repo: skylight.digital
   date: '2026-03-26'
-  type: photo
+  type: illustration
   themes:
   - brand
   tags: []
@@ -1104,7 +1102,7 @@
   path: identity/typography/typefaces.jpg
   repo: skylight.digital
   date: '2026-03-26'
-  type: photo
+  type: diagram
   themes:
   - brand
   tags: []
@@ -1132,7 +1130,7 @@
   path: identity/typography/usage.jpg
   repo: skylight.digital
   date: '2026-03-26'
-  type: photo
+  type: diagram
   themes:
   - brand
   tags: []
@@ -1308,7 +1306,7 @@
   path: illustration/primary-colors.jpg
   repo: skylight.digital
   date: '2026-03-26'
-  type: photo
+  type: illustration
   themes:
   - brand
   tags: []
@@ -1323,7 +1321,7 @@
   path: illustration/skin-and-hair.jpg
   repo: skylight.digital
   date: '2026-03-26'
-  type: photo
+  type: illustration
   themes:
   - brand
   tags: []
@@ -1338,7 +1336,7 @@
   path: illustration/style-1.jpg
   repo: skylight.digital
   date: '2026-03-26'
-  type: photo
+  type: illustration
   themes:
   - brand
   tags: []
@@ -1353,7 +1351,7 @@
   path: illustration/style-2.jpg
   repo: skylight.digital
   date: '2026-03-26'
-  type: photo
+  type: illustration
   themes:
   - brand
   tags: []

--- a/img/brand/assets-manifest.yml
+++ b/img/brand/assets-manifest.yml
@@ -5,6 +5,8 @@
 # public site -> permissions: skylight-owned, classification: public.
 # ids are path-based (unique within the repo + distinct from the hub's
 # brand-pack manifest, which vendors a subset of these same logos).
+# type logo = actual logo files (identity/assets/logos + icon/avatar); the
+# identity/logos/** guide section is diagrams/examples about logo usage.
 # Schema: standards/asset-manifest-schema.yml; validate: ruby scripts/check_asset_manifests.rb
 - id: hero-identity-colors
   path: hero/identity/colors.svg
@@ -680,13 +682,12 @@
   path: identity/logos/behind-the-design--halo.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo variant: Behind The Design Halo'
-  description: Skylight logo variant (Behind The Design Halo) from the brand identity
-    asset set.
+  alt: "'Behind the design' explainer: the halo"
+  description: Brand-guide explainer of how the halo logomark is constructed.
   permissions: skylight-owned
   classification: public
   archived: false
@@ -695,13 +696,12 @@
   path: identity/logos/behind-the-design--type.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo variant: Behind The Design Type'
-  description: Skylight logo variant (Behind The Design Type) from the brand identity
-    asset set.
+  alt: "'Behind the design' explainer: the logotype"
+  description: Brand-guide explainer of how the Skylight logotype is constructed.
   permissions: skylight-owned
   classification: public
   archived: false
@@ -710,13 +710,12 @@
   path: identity/logos/general-positioning.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo variant: General Positioning'
-  description: Skylight logo variant (General Positioning) from the brand identity
-    asset set.
+  alt: Logo positioning guidance diagram
+  description: Brand-guide diagram showing general logo positioning guidance.
   permissions: skylight-owned
   classification: public
   archived: false
@@ -725,13 +724,12 @@
   path: identity/logos/list-indicator--1.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo variant: List Indicator 1'
-  description: Skylight logo variant (List Indicator 1) from the brand identity asset
-    set.
+  alt: 'Logo brand-element graphic: List Indicator 1'
+  description: Brand-guide logo-section graphic element (List Indicator 1).
   permissions: skylight-owned
   classification: public
   archived: false
@@ -740,13 +738,12 @@
   path: identity/logos/list-indicator--2.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo variant: List Indicator 2'
-  description: Skylight logo variant (List Indicator 2) from the brand identity asset
-    set.
+  alt: 'Logo brand-element graphic: List Indicator 2'
+  description: Brand-guide logo-section graphic element (List Indicator 2).
   permissions: skylight-owned
   classification: public
   archived: false
@@ -755,13 +752,12 @@
   path: identity/logos/list-indicator--3.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo variant: List Indicator 3'
-  description: Skylight logo variant (List Indicator 3) from the brand identity asset
-    set.
+  alt: 'Logo brand-element graphic: List Indicator 3'
+  description: Brand-guide logo-section graphic element (List Indicator 3).
   permissions: skylight-owned
   classification: public
   archived: false
@@ -774,8 +770,9 @@
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo variant: Logotype'
-  description: Skylight logo variant (Logotype) from the brand identity asset set.
+  alt: Skylight logotype (wordmark) without the halo
+  description: 'The Skylight logotype: the ''Skylight'' wordmark on its own, without
+    the halo logomark.'
   permissions: skylight-owned
   classification: public
   archived: false
@@ -784,13 +781,13 @@
   path: identity/logos/minimum-sizes.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo variant: Minimum Sizes'
-  description: Skylight logo variant (Minimum Sizes) from the brand identity asset
-    set.
+  alt: Logo minimum-size diagram
+  description: Brand-guide diagram showing the logo's minimum sizes for digital and
+    print.
   permissions: skylight-owned
   classification: public
   archived: false
@@ -799,12 +796,12 @@
   path: identity/logos/positioning/bottom-left.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo positioning diagram: Bottom Left'
-  description: Brand-guide logo positioning / clear-space diagram (Bottom Left).
+  alt: 'Logo positioning diagram: Bottom Left'
+  description: Brand-guide logo positioning diagram (Bottom Left placement).
   permissions: skylight-owned
   classification: public
   archived: false
@@ -813,12 +810,12 @@
   path: identity/logos/positioning/bottom-right.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo positioning diagram: Bottom Right'
-  description: Brand-guide logo positioning / clear-space diagram (Bottom Right).
+  alt: 'Logo positioning diagram: Bottom Right'
+  description: Brand-guide logo positioning diagram (Bottom Right placement).
   permissions: skylight-owned
   classification: public
   archived: false
@@ -827,12 +824,12 @@
   path: identity/logos/positioning/top-left.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo positioning diagram: Top Left'
-  description: Brand-guide logo positioning / clear-space diagram (Top Left).
+  alt: 'Logo positioning diagram: Top Left'
+  description: Brand-guide logo positioning diagram (Top Left placement).
   permissions: skylight-owned
   classification: public
   archived: false
@@ -841,12 +838,12 @@
   path: identity/logos/positioning/top-right.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo positioning diagram: Top Right'
-  description: Brand-guide logo positioning / clear-space diagram (Top Right).
+  alt: 'Logo positioning diagram: Top Right'
+  description: Brand-guide logo positioning diagram (Top Right placement).
   permissions: skylight-owned
   classification: public
   archived: false
@@ -855,12 +852,12 @@
   path: identity/logos/rotation.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo variant: Rotation'
-  description: Skylight logo variant (Rotation) from the brand identity asset set.
+  alt: Logo rotation rules diagram
+  description: Brand-guide diagram showing sanctioned vs. forbidden logo rotations.
   permissions: skylight-owned
   classification: public
   archived: false
@@ -869,12 +866,12 @@
   path: identity/logos/spacing.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo variant: Spacing'
-  description: Skylight logo variant (Spacing) from the brand identity asset set.
+  alt: Logo clear-space diagram
+  description: Brand-guide diagram showing the required clear space around the logo.
   permissions: skylight-owned
   classification: public
   archived: false
@@ -883,13 +880,12 @@
   path: identity/logos/things-to-avoid.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo variant: Things To Avoid'
-  description: Skylight logo variant (Things To Avoid) from the brand identity asset
-    set.
+  alt: Logo misuse overview
+  description: Brand-guide overview of logo treatments to avoid.
   permissions: skylight-owned
   classification: public
   archived: false
@@ -898,11 +894,11 @@
   path: identity/logos/things-to-avoid/bg-image.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo misuse example: Bg Image'
+  alt: 'Logo misuse example: Bg Image'
   description: Brand-guide 'things to avoid' example showing an incorrect logo treatment
     (Bg Image).
   permissions: skylight-owned
@@ -913,11 +909,11 @@
   path: identity/logos/things-to-avoid/diagonal.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo misuse example: Diagonal'
+  alt: 'Logo misuse example: Diagonal'
   description: Brand-guide 'things to avoid' example showing an incorrect logo treatment
     (Diagonal).
   permissions: skylight-owned
@@ -928,11 +924,11 @@
   path: identity/logos/things-to-avoid/image-type.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo misuse example: Image Type'
+  alt: 'Logo misuse example: Image Type'
   description: Brand-guide 'things to avoid' example showing an incorrect logo treatment
     (Image Type).
   permissions: skylight-owned
@@ -943,11 +939,11 @@
   path: identity/logos/things-to-avoid/mono-type.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo misuse example: Mono Type'
+  alt: 'Logo misuse example: Mono Type'
   description: Brand-guide 'things to avoid' example showing an incorrect logo treatment
     (Mono Type).
   permissions: skylight-owned
@@ -958,11 +954,11 @@
   path: identity/logos/things-to-avoid/outline-type.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo misuse example: Outline Type'
+  alt: 'Logo misuse example: Outline Type'
   description: Brand-guide 'things to avoid' example showing an incorrect logo treatment
     (Outline Type).
   permissions: skylight-owned
@@ -973,11 +969,11 @@
   path: identity/logos/things-to-avoid/red-type.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo misuse example: Red Type'
+  alt: 'Logo misuse example: Red Type'
   description: Brand-guide 'things to avoid' example showing an incorrect logo treatment
     (Red Type).
   permissions: skylight-owned
@@ -988,11 +984,11 @@
   path: identity/logos/things-to-avoid/spaced-type.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo misuse example: Spaced Type'
+  alt: 'Logo misuse example: Spaced Type'
   description: Brand-guide 'things to avoid' example showing an incorrect logo treatment
     (Spaced Type).
   permissions: skylight-owned
@@ -1003,11 +999,11 @@
   path: identity/logos/things-to-avoid/squished-type.svg
   repo: skylight.digital
   date: '2026-03-26'
-  type: logo
+  type: diagram
   themes:
   - brand
   tags: []
-  alt: 'Skylight logo misuse example: Squished Type'
+  alt: 'Logo misuse example: Squished Type'
   description: Brand-guide 'things to avoid' example showing an incorrect logo treatment
     (Squished Type).
   permissions: skylight-owned

--- a/scripts/check_asset_manifests.rb
+++ b/scripts/check_asset_manifests.rb
@@ -1,0 +1,411 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Tier 3 — federation asset registry per-repo validator.
+#
+# Walks the current repo for asset manifests (assets-manifest.yml +
+# image-library.yml), validates every entry against the canonical schema
+# (standards/asset-manifest-schema.yml) and controlled vocabulary
+# (standards/asset-vocabulary.yml).
+#
+# Checks performed per entry:
+#   - Required fields present (id, path, repo, date, type, permissions,
+#     classification, archived, pending_classification)
+#   - Enum compliance (type, permissions, classification, archived_reason,
+#     landed_via against asset-vocabulary.yml; repo against the inline list)
+#   - Pattern compliance (id kebab-case; date ISO YYYY-MM-DD; archived_at +
+#     landed_at same shape)
+#   - File ↔ manifest correspondence — manifest `path:` resolves to an
+#     existing file in the repo (or, when archived: true, in the matching
+#     `_archived/` subdir)
+#   - Cross-field rules:
+#       * archived: true ⟹ archived_at + archived_reason both present
+#       * pending_classification: true ⟹ landed_at + landed_via both present
+#       * pending_classification: true ⟹ set_id: null AND used_in: []
+#       * archived AND pending_classification mutually exclusive
+#       * moved_to set ⟹ archived: true
+#   - Vocab warnings (not failures): unknown themes / tags
+#   - Long-pending review-needed warnings: permissions: review-needed AND
+#     archived: false → WARN (advisory, not blocking)
+#
+# Exit codes:
+#   0 — all checks pass (warnings allowed)
+#   1 — one or more blocking findings
+#   2 — bad invocation (missing schema, missing vocab, etc.)
+#
+# Run from repo root:
+#   ruby scripts/check_asset_manifests.rb
+#
+# Optional flags:
+#   --warn-as-error      Promote all warnings to errors (CI strict mode)
+#   --quiet              Suppress per-entry OK output; only show findings
+#   --manifest <path>    Validate a specific manifest file rather than the
+#                        full repo sweep (useful for pre-commit hook integration)
+#
+# Source proposal: plans/active/federation-asset-registry.md
+# Source migration: migrations/federation-asset-registry-bootstrap.md
+
+require "yaml"
+require "pathname"
+
+REPO_ROOT  = Pathname.new(File.expand_path("..", __dir__))
+SCHEMA     = YAML.load_file(REPO_ROOT.join("standards/asset-manifest-schema.yml"))
+VOCAB      = YAML.load_file(REPO_ROOT.join("standards/asset-vocabulary.yml"))
+
+# -- CLI -----------------------------------------------------------------------
+
+opts = { warn_as_error: false, quiet: false, manifest: nil }
+ARGV.each_with_index do |arg, i|
+  case arg
+  when "--warn-as-error" then opts[:warn_as_error] = true
+  when "--quiet"         then opts[:quiet] = true
+  when "--manifest"
+    opts[:manifest] = ARGV[i + 1]
+    raise ArgumentError, "--manifest requires a path" if opts[:manifest].nil?
+  when "--help", "-h"
+    # Read with explicit UTF-8 encoding so non-ASCII chars in this header
+    # (em-dashes etc.) don't trip a US-ASCII default locale.
+    puts File.read(__FILE__, encoding: "UTF-8").lines.grep(/^# /).join
+    exit 0
+  end
+end
+
+# -- Helpers -------------------------------------------------------------------
+
+class Finding
+  attr_reader :manifest, :entry_id, :level, :code, :message
+
+  def initialize(manifest:, entry_id:, level:, code:, message:)
+    @manifest  = manifest
+    @entry_id  = entry_id
+    @level     = level # :error | :warn
+    @code      = code
+    @message   = message
+  end
+
+  def to_s
+    location = "#{manifest}#{entry_id ? " [#{entry_id}]" : ''}"
+    prefix   = level == :error ? "ERROR" : "WARN "
+    "#{prefix} #{code} in #{location}: #{message}"
+  end
+end
+
+def schema_required_keys
+  SCHEMA.fetch("required")
+end
+
+def schema_property(field)
+  SCHEMA.fetch("properties").fetch(field, nil)
+end
+
+def vocab_themes;            VOCAB.fetch("themes", []);           end
+def vocab_tags;              VOCAB.fetch("tags", []);             end
+def vocab_archive_reasons;   VOCAB.fetch("archive_reasons", []);  end
+def vocab_landed_via;        VOCAB.fetch("landed_via", []);       end
+
+def enum_for(field)
+  prop = schema_property(field)
+  prop && prop["enum"]
+end
+
+def pattern_for(field)
+  prop = schema_property(field)
+  prop && prop["pattern"]
+end
+
+# -- Validation ----------------------------------------------------------------
+
+def validate_entry(entry, manifest_path:, findings:)
+  entry_id = entry["id"] || "<missing id>"
+
+  # 1. Required fields
+  missing = schema_required_keys - entry.keys
+  missing.each do |field|
+    findings << Finding.new(
+      manifest:  manifest_path,
+      entry_id:  entry_id,
+      level:     :error,
+      code:      "missing-required-field",
+      message:   "required field '#{field}' is missing",
+    )
+  end
+  return if missing.any? # short-circuit; downstream checks assume required fields exist
+
+  # 2. Pattern compliance
+  %w[id date archived_at landed_at].each do |field|
+    value = entry[field]
+    next if value.nil? || value.empty?
+    pattern = pattern_for(field)
+    next if pattern.nil?
+    unless value.match?(Regexp.new(pattern))
+      findings << Finding.new(
+        manifest:  manifest_path,
+        entry_id:  entry_id,
+        level:     :error,
+        code:      "pattern-violation",
+        message:   "field '#{field}' value '#{value}' does not match #{pattern}",
+      )
+    end
+  end
+
+  # 3. Enum compliance — schema-defined enums
+  %w[type permissions classification repo].each do |field|
+    value = entry[field]
+    next if value.nil?
+    allowed = enum_for(field)
+    next if allowed.nil?
+    unless allowed.include?(value)
+      findings << Finding.new(
+        manifest:  manifest_path,
+        entry_id:  entry_id,
+        level:     :error,
+        code:      "enum-violation",
+        message:   "field '#{field}' value '#{value}' not in #{allowed.inspect}",
+      )
+    end
+  end
+
+  # 4. Vocab enum compliance (vocab-driven enums)
+  if entry["archived"] == true && entry["archived_reason"]
+    unless vocab_archive_reasons.include?(entry["archived_reason"])
+      findings << Finding.new(
+        manifest:  manifest_path,
+        entry_id:  entry_id,
+        level:     :error,
+        code:      "vocab-violation",
+        message:   "archived_reason '#{entry['archived_reason']}' not in asset-vocabulary.yml archive_reasons",
+      )
+    end
+  end
+  if entry["pending_classification"] == true && entry["landed_via"]
+    unless vocab_landed_via.include?(entry["landed_via"])
+      findings << Finding.new(
+        manifest:  manifest_path,
+        entry_id:  entry_id,
+        level:     :error,
+        code:      "vocab-violation",
+        message:   "landed_via '#{entry['landed_via']}' not in asset-vocabulary.yml landed_via",
+      )
+    end
+  end
+
+  # 5. Vocab warnings (open vocab)
+  (entry["themes"] || []).each do |theme|
+    unless vocab_themes.include?(theme)
+      findings << Finding.new(
+        manifest:  manifest_path,
+        entry_id:  entry_id,
+        level:     :warn,
+        code:      "unknown-theme",
+        message:   "theme '#{theme}' not in asset-vocabulary.yml themes — add it there if intentional",
+      )
+    end
+  end
+  (entry["tags"] || []).each do |tag|
+    unless vocab_tags.include?(tag)
+      findings << Finding.new(
+        manifest:  manifest_path,
+        entry_id:  entry_id,
+        level:     :warn,
+        code:      "unknown-tag",
+        message:   "tag '#{tag}' not in asset-vocabulary.yml tags — add it there if intentional",
+      )
+    end
+  end
+
+  # 6. File ↔ manifest correspondence
+  manifest_dir = Pathname.new(manifest_path).dirname
+  resolved_path = manifest_dir.join(entry["path"])
+  unless resolved_path.exist?
+    findings << Finding.new(
+      manifest:  manifest_path,
+      entry_id:  entry_id,
+      level:     :error,
+      code:      "missing-file",
+      message:   "path '#{entry['path']}' does not resolve to an existing file (looked at #{resolved_path})",
+    )
+  end
+
+  # 7. Cross-field rules
+  if entry["archived"] == true
+    if entry["archived_at"].nil? || entry["archived_at"].to_s.empty?
+      findings << Finding.new(
+        manifest:  manifest_path,
+        entry_id:  entry_id,
+        level:     :error,
+        code:      "archived-missing-date",
+        message:   "archived: true requires archived_at",
+      )
+    end
+    if entry["archived_reason"].nil? || entry["archived_reason"].to_s.empty?
+      findings << Finding.new(
+        manifest:  manifest_path,
+        entry_id:  entry_id,
+        level:     :error,
+        code:      "archived-missing-reason",
+        message:   "archived: true requires archived_reason",
+      )
+    end
+  end
+
+  if entry["pending_classification"] == true
+    if entry["landed_at"].nil? || entry["landed_at"].to_s.empty?
+      findings << Finding.new(
+        manifest:  manifest_path,
+        entry_id:  entry_id,
+        level:     :error,
+        code:      "pending-missing-landed-at",
+        message:   "pending_classification: true requires landed_at",
+      )
+    end
+    if entry["landed_via"].nil? || entry["landed_via"].to_s.empty?
+      findings << Finding.new(
+        manifest:  manifest_path,
+        entry_id:  entry_id,
+        level:     :error,
+        code:      "pending-missing-landed-via",
+        message:   "pending_classification: true requires landed_via",
+      )
+    end
+    if entry["set_id"]
+      findings << Finding.new(
+        manifest:  manifest_path,
+        entry_id:  entry_id,
+        level:     :error,
+        code:      "pending-with-set",
+        message:   "pending_classification: true requires set_id: null (got '#{entry['set_id']}')",
+      )
+    end
+    if (entry["used_in"] || []).any?
+      findings << Finding.new(
+        manifest:  manifest_path,
+        entry_id:  entry_id,
+        level:     :error,
+        code:      "pending-with-used-in",
+        message:   "pending_classification: true requires used_in: [] (got #{entry['used_in'].inspect})",
+      )
+    end
+  end
+
+  if entry["archived"] == true && entry["pending_classification"] == true
+    findings << Finding.new(
+      manifest:  manifest_path,
+      entry_id:  entry_id,
+      level:     :error,
+      code:      "archived-and-pending",
+      message:   "archived: true and pending_classification: true are mutually exclusive",
+    )
+  end
+
+  if entry["moved_to"] && entry["archived"] != true
+    findings << Finding.new(
+      manifest:  manifest_path,
+      entry_id:  entry_id,
+      level:     :error,
+      code:      "moved-to-not-archived",
+      message:   "moved_to set ('#{entry['moved_to']}') requires archived: true on the source row",
+    )
+  end
+
+  # 8. Advisory warnings (long-pending review-needed)
+  if entry["permissions"] == "review-needed" && entry["archived"] == false
+    findings << Finding.new(
+      manifest:  manifest_path,
+      entry_id:  entry_id,
+      level:     :warn,
+      code:      "review-needed-pending",
+      message:   "permissions: review-needed entries should be downgraded or archived once review completes",
+    )
+  end
+end
+
+def discover_manifests(root:)
+  manifests = []
+  Dir.glob(root.join("**/{assets-manifest,image-library}.yml")).each do |path|
+    # Skip lifecycle dirs and node_modules; the validator reads main repo content.
+    next if path.include?("/node_modules/")
+    next if path.include?("/_archived/")
+    next if path.include?("/_incoming/")
+    manifests << path
+  end
+  manifests.sort
+end
+
+# -- Main ----------------------------------------------------------------------
+
+findings = []
+
+manifests =
+  if opts[:manifest]
+    p = Pathname.new(opts[:manifest])
+    unless p.exist?
+      warn "ERROR: --manifest path does not exist: #{opts[:manifest]}"
+      exit 2
+    end
+    [p.to_s]
+  else
+    discover_manifests(root: REPO_ROOT)
+  end
+
+if manifests.empty?
+  puts "(no asset manifests found — federation asset registry not yet bootstrapped in this repo)"
+  exit 0
+end
+
+manifests.each do |path|
+  data =
+    begin
+      YAML.load_file(path)
+    rescue StandardError => e
+      findings << Finding.new(manifest: path, entry_id: nil, level: :error, code: "yaml-parse-error", message: e.message)
+      next
+    end
+
+  unless data.is_a?(Hash) || data.is_a?(Array)
+    findings << Finding.new(manifest: path, entry_id: nil, level: :error, code: "bad-manifest-shape", message: "top-level structure must be a mapping or sequence")
+    next
+  end
+
+  # Manifests may be either:
+  #   (a) a top-level array of entries (compact form)
+  #   (b) a mapping with `images:` or `assets:` key containing the array (matches the
+  #       skylight-marcom social-post image-library.yml shape)
+  entries =
+    if data.is_a?(Array)
+      data
+    elsif data["images"]
+      data["images"]
+    elsif data["assets"]
+      data["assets"]
+    else
+      []
+    end
+
+  next if entries.nil? || entries.empty?
+
+  entries.each do |entry|
+    next unless entry.is_a?(Hash)
+    validate_entry(entry, manifest_path: path, findings: findings)
+  end
+
+  unless opts[:quiet]
+    entry_count = entries.size
+    err_count   = findings.count { |f| f.manifest == path && f.level == :error }
+    warn_count  = findings.count { |f| f.manifest == path && f.level == :warn }
+    status      = err_count.zero? ? "OK" : "FAIL"
+    puts "#{status} #{path}: #{entry_count} entries (#{err_count} errors, #{warn_count} warnings)"
+  end
+end
+
+# -- Report --------------------------------------------------------------------
+
+errors   = findings.count { |f| f.level == :error }
+warnings = findings.count { |f| f.level == :warn }
+
+findings.each { |f| puts f.to_s }
+
+puts
+puts "#{errors} error(s), #{warnings} warning(s) across #{manifests.size} manifest(s)"
+
+blocking = errors + (opts[:warn_as_error] ? warnings : 0)
+exit(blocking.zero? ? 0 : 1)

--- a/scripts/scaffold_asset_manifest.rb
+++ b/scripts/scaffold_asset_manifest.rb
@@ -1,0 +1,318 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Tier 3 — federation asset registry manifest scaffolder.
+#
+# Walks a target directory for image / video / pdf files and emits a manifest
+# (YAML) with auto-populated metadata. Auto-fills the mechanical fields
+# (id, path, repo, date, type) from path heuristics + filename + file mtime;
+# leaves the judgment fields (description, themes, tags, alt, permissions,
+# classification) for human enrichment.
+#
+# The deliberate principle here is that the scaffolder should *never guess*
+# at the judgment fields — wrong values in `themes:` or `permissions:` are
+# worse than missing values because a confident-but-wrong manifest entry
+# hides itself from the human-enrichment workflow.
+#
+# Run from repo root:
+#   ruby scripts/scaffold_asset_manifest.rb <target-dir> [--out <path>] [--repo <name>] [--shape compact|keyed]
+#
+# Examples:
+#   # Scaffold a manifest for hub's standards/images/ directory
+#   ruby scripts/scaffold_asset_manifest.rb standards/images \
+#     --out standards/assets-manifest.yml --repo skylight-hub
+#
+#   # Same but emit a keyed (images:) manifest shape:
+#   ruby scripts/scaffold_asset_manifest.rb standards/images \
+#     --out standards/assets-manifest.yml --repo skylight-hub --shape keyed
+#
+#   # Print to stdout instead of writing:
+#   ruby scripts/scaffold_asset_manifest.rb plugins/skylight-brand-pack/assets
+#
+# Behavior:
+#   - Walks the target directory recursively.
+#   - For each asset:
+#     - Generates a stable kebab-case `id` from the basename.
+#     - Sets `path` relative to <target-dir>'s manifest location.
+#     - Infers `type` from path heuristics (mirrors scan_assets.rb).
+#     - Sets `date` from EXIF when readable (uses `exiftool` if available),
+#       falls back to file mtime (ISO YYYY-MM-DD).
+#     - Sets `repo` from --repo (default: directory's repo name).
+#     - Sets `archived: false`, `pending_classification: false`.
+#     - Leaves the judgment fields empty for human enrichment, with a
+#       comment header above each entry explaining what to fill in.
+#   - Skips assets already covered by an existing manifest (cross-references
+#     against `**/{assets-manifest,image-library}.yml` like check_asset_manifests).
+#   - Skips `_archived/` and `_incoming/` lifecycle subdirs.
+#
+# Exit codes:
+#   0 — scaffold completed (count printed to stderr)
+#   2 — bad invocation
+#
+# Source proposal: plans/active/federation-asset-registry.md
+# Source migration: migrations/federation-asset-registry-phase-a-tooling-followup.md
+# Predecessor: archive/2026-05-23-federation-asset-registry-bootstrap.md (Phase A scaffold)
+
+require "yaml"
+require "pathname"
+require "date"
+require "set"
+
+REPO_ROOT  = Pathname.new(File.expand_path("..", __dir__))
+IMAGE_EXTS = %w[png jpg jpeg gif webp svg tiff bmp].freeze
+VIDEO_EXTS = %w[mp4 mov webm m4v].freeze
+PDF_EXTS   = %w[pdf].freeze
+ALL_EXTS   = (IMAGE_EXTS + VIDEO_EXTS + PDF_EXTS).freeze
+
+REPO_ENUM = %w[
+  skylight-hub
+  skylight.digital
+  skylight-marcom
+  skylight-people-ops
+  skylight-hub-proposals-resolve
+].freeze
+
+# -- CLI ---------------------------------------------------------------------
+
+opts = { target: nil, out: nil, repo: nil, shape: "compact" }
+i = 0
+while i < ARGV.length
+  arg = ARGV[i]
+  case arg
+  when "--out"     then opts[:out]   = ARGV[i + 1]; i += 1
+  when "--repo"    then opts[:repo]  = ARGV[i + 1]; i += 1
+  when "--shape"   then opts[:shape] = ARGV[i + 1]; i += 1
+  when "--help", "-h"
+    # Read with explicit UTF-8 encoding so non-ASCII chars in this header
+    # (em-dashes etc.) don't trip a US-ASCII default locale.
+    puts File.read(__FILE__, encoding: "UTF-8").lines.grep(/^# /).join
+    exit 0
+  else
+    if opts[:target].nil?
+      opts[:target] = arg
+    else
+      warn "ERROR: unknown argument '#{arg}'"
+      exit 2
+    end
+  end
+  i += 1
+end
+
+if opts[:target].nil?
+  warn "Usage: ruby scaffold_asset_manifest.rb <target-dir> [--out <path>] [--repo <name>] [--shape compact|keyed]"
+  exit 2
+end
+
+unless %w[compact keyed].include?(opts[:shape])
+  warn "ERROR: --shape must be 'compact' or 'keyed'"
+  exit 2
+end
+
+target_dir = Pathname.new(opts[:target]).expand_path
+unless target_dir.directory?
+  warn "ERROR: not a directory: #{opts[:target]}"
+  exit 2
+end
+
+# Resolve repo name. Priority: --repo flag → derive from target path's repo root → fallback to "skylight-hub".
+def derive_repo(path)
+  current = path
+  while current.parent != current
+    git_dir = current + ".git"
+    return current.basename.to_s if git_dir.directory? || git_dir.file?
+    current = current.parent
+  end
+  nil
+end
+
+repo_name = opts[:repo] || derive_repo(target_dir) || "skylight-hub"
+unless REPO_ENUM.include?(repo_name)
+  warn "WARN: repo '#{repo_name}' not in canonical enum #{REPO_ENUM.inspect}; manifest will fail validator. Continuing anyway."
+end
+
+manifest_dir =
+  if opts[:out]
+    Pathname.new(opts[:out]).expand_path.dirname
+  else
+    target_dir
+  end
+
+# -- Helpers -----------------------------------------------------------------
+
+def kebab(s)
+  s.to_s.downcase
+   .gsub(/\.\w+$/, "")               # strip ext
+   .gsub(/[^a-z0-9]+/, "-")          # non-alnum → hyphen
+   .gsub(/^-+|-+$/, "")              # trim leading/trailing
+   .gsub(/-+/, "-")                  # collapse runs
+end
+
+def type_guess(path, ext)
+  basename = File.basename(path).downcase
+  path_str = path.to_s.downcase
+  return "gif"      if ext == "gif"
+  return "pdf"      if PDF_EXTS.include?(ext)
+  return "video"    if VIDEO_EXTS.include?(ext)
+  return "headshot" if path_str.match?(%r{/team/|headshot}) && IMAGE_EXTS.include?(ext)
+  return "logo"     if basename.match?(/logo/) || path_str.match?(%r{/logos?/})
+  return "diagram"  if ext == "svg" && !path_str.match?(%r{/logos?/})
+  return "hero"     if basename.match?(/hero/) || path_str.match?(%r{/projects/[^/]+/hero})
+  return "screenshot" if basename.match?(/screenshot|screencap|capture/) ||
+                        path_str.match?(%r{/screenshots?/|/reference/images/})
+  return "photo"    if IMAGE_EXTS.include?(ext)
+  "photo"
+end
+
+def exiftool_available?
+  return @exiftool_available unless @exiftool_available.nil?
+  @exiftool_available = system("which exiftool > /dev/null 2>&1")
+end
+
+def exif_date(file)
+  return nil unless exiftool_available?
+  out = `exiftool -s -s -s -DateTimeOriginal '#{file}' 2>/dev/null`
+  return nil if out.strip.empty?
+  # EXIF format: 2024:05:15 14:33:21 — convert to YYYY-MM-DD
+  m = out.strip.match(/^(\d{4}):(\d{2}):(\d{2})/)
+  return nil unless m
+  "#{m[1]}-#{m[2]}-#{m[3]}"
+rescue StandardError
+  nil
+end
+
+def file_date(file)
+  Date.new(file.mtime.year, file.mtime.month, file.mtime.day).strftime("%Y-%m-%d")
+end
+
+def discover_existing_manifest_entries(root)
+  seen = Set.new
+  Dir.glob(root.join("**/{assets-manifest,image-library}.yml")).each do |path|
+    next if path.include?("/node_modules/")
+    data =
+      begin
+        YAML.safe_load(File.read(path), permitted_classes: [Date, Time])
+      rescue StandardError
+        next
+      end
+    entries =
+      if data.is_a?(Array)
+        data
+      elsif data.is_a?(Hash) && data["images"]
+        data["images"]
+      elsif data.is_a?(Hash) && data["assets"]
+        data["assets"]
+      else
+        []
+      end
+    entries.each do |e|
+      next unless e.is_a?(Hash) && e["path"]
+      resolved = Pathname.new(path).dirname.join(e["path"]).cleanpath
+      seen << resolved.to_s
+    end
+  end
+  seen
+end
+
+# -- Walk + build entries ----------------------------------------------------
+
+already_in_manifest = discover_existing_manifest_entries(REPO_ROOT)
+
+assets = []
+ALL_EXTS.each do |ext|
+  Dir.glob(target_dir.join("**", "*.#{ext}"), File::FNM_CASEFOLD).each do |file|
+    p = Pathname.new(file)
+    next unless p.file?
+    next if p.to_s.include?("/_archived/") || p.to_s.include?("/_incoming/")
+    next if already_in_manifest.include?(p.cleanpath.to_s)
+    assets << p
+  end
+end
+assets.uniq! { |p| p.to_s }
+assets.sort_by!(&:to_s)
+
+used_ids = {}
+
+def unique_id(base, used)
+  base = "asset" if base.nil? || base.empty?
+  return base unless used.key?(base)
+  i = 2
+  i += 1 while used.key?("#{base}-#{i}")
+  "#{base}-#{i}"
+end
+
+entries = assets.map do |file|
+  ext = File.extname(file).downcase.delete(".")
+  begin
+    rel_path = file.relative_path_from(manifest_dir).to_s
+  rescue ArgumentError => e
+    warn "ERROR: cannot express asset path relative to manifest dir (#{e.message}). Asset: #{file}; manifest dir: #{manifest_dir}."
+    exit 2
+  end
+  date = exif_date(file) || file_date(file)
+  id = unique_id(kebab(file.basename.to_s), used_ids)
+  used_ids[id] = true
+  {
+    "id"                     => id,
+    "path"                   => rel_path,
+    "repo"                   => repo_name,
+    "date"                   => date,
+    "type"                   => type_guess(file, ext),
+    # Judgment fields left null/empty for human enrichment.
+    "themes"                 => [],
+    "tags"                   => [],
+    "people"                 => [],
+    "event"                  => nil,
+    "alt"                    => "",
+    "description"            => "",
+    "permissions"            => "review-needed",  # safe default — forces human to confirm rights
+    "classification"         => "internal",       # safe default — most images aren't public yet
+    "set_id"                 => nil,
+    "used_in"                => [],
+    "archived"               => false,
+    "archived_at"            => nil,
+    "archived_reason"        => nil,
+    "pending_classification" => false,
+    "landed_at"              => nil,
+    "landed_via"             => nil,
+    "notes"                  => nil,
+  }
+end
+
+# -- Emit --------------------------------------------------------------------
+
+header = <<~YAML
+  # Auto-scaffolded by scripts/scaffold_asset_manifest.rb on #{Date.today.strftime('%Y-%m-%d')}.
+  #
+  # Mechanical fields (id, path, repo, date, type) are filled in.
+  # Judgment fields (themes, tags, alt, description, permissions, classification)
+  # need human enrichment. Defaults:
+  #   - permissions: "review-needed" (forces an explicit rights review before publishing)
+  #   - classification: "internal" (downgrade to "public" once cleared)
+  #
+  # Run `ruby scripts/check_asset_manifests.rb` after editing to validate.
+YAML
+
+if opts[:shape] == "keyed"
+  payload = {
+    "meta" => {
+      "schema_version"   => 1,
+      "scaffolded_at"    => Date.today.strftime("%Y-%m-%d"),
+      "scaffolded_by"    => "scripts/scaffold_asset_manifest.rb",
+      "target_directory" => target_dir.relative_path_from(REPO_ROOT).to_s,
+    },
+    "images" => entries,
+  }
+  output = header + payload.to_yaml.sub(/^---\n/, "")
+else
+  output = header + entries.to_yaml.sub(/^---\n/, "")
+end
+
+if opts[:out]
+  File.write(opts[:out], output)
+  warn "scaffolded #{entries.size} entry(ies) into #{opts[:out]} (shape: #{opts[:shape]})"
+else
+  print output
+  warn "scaffolded #{entries.size} entry(ies) for #{target_dir} (shape: #{opts[:shape]}; stdout)"
+end
+
+exit 0

--- a/scripts/scan_assets.rb
+++ b/scripts/scan_assets.rb
@@ -1,0 +1,200 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Tier 3 — federation asset registry inventory walker.
+#
+# Walks the current repo for image / video / pdf files, emits a raw
+# inventory (YAML or CSV) that downstream tooling (scaffold_asset_manifest.rb,
+# the human-enrichment workflow) consumes to populate per-repo manifests.
+#
+# Does NOT validate or modify manifests; that's check_asset_manifests.rb's
+# job. This script only enumerates.
+#
+# Run from repo root:
+#   ruby scripts/scan_assets.rb                # YAML to stdout
+#   ruby scripts/scan_assets.rb --format=csv   # CSV to stdout
+#   ruby scripts/scan_assets.rb --out inventory.yml
+#
+# Output schema (per row):
+#   path:               repo-relative path
+#   size_bytes:         file size in bytes
+#   ext:                file extension (lowercased, no dot)
+#   type_guess:         inferred from path + ext (photo | screenshot | diagram |
+#                       gif | video | pdf | logo | hero | headshot | unknown)
+#   in_manifest:        true | false — whether any discovered manifest already
+#                       carries a row for this path
+#   manifest_path:      path to the manifest holding the row, or null
+#   archived_dir:       true if file sits in an _archived/ subdir
+#   incoming_dir:       true if file sits in an _incoming/ subdir
+#
+# Exit codes:
+#   0 — scan completed (file count printed to stderr)
+#   2 — bad invocation
+#
+# Source proposal: plans/active/federation-asset-registry.md
+# Source migration: migrations/federation-asset-registry-bootstrap.md
+
+require "yaml"
+require "csv"
+require "pathname"
+require "digest"
+
+REPO_ROOT = Pathname.new(File.expand_path("..", __dir__))
+
+IMAGE_EXTS = %w[png jpg jpeg gif webp svg tiff bmp].freeze
+VIDEO_EXTS = %w[mp4 mov webm m4v].freeze
+PDF_EXTS   = %w[pdf].freeze
+ALL_EXTS   = (IMAGE_EXTS + VIDEO_EXTS + PDF_EXTS).freeze
+
+# -- CLI -----------------------------------------------------------------------
+
+opts = { format: "yaml", out: nil, root: REPO_ROOT }
+i = 0
+while i < ARGV.length
+  arg = ARGV[i]
+  case arg
+  when "--format"
+    opts[:format] = ARGV[i + 1] or (warn("ERROR: --format requires a value"); exit 2)
+    i += 1
+  when /\A--format=(.+)\z/
+    opts[:format] = Regexp.last_match(1)
+  when "--out"
+    opts[:out] = ARGV[i + 1] or (warn("ERROR: --out requires a path"); exit 2)
+    i += 1
+  when /\A--out=(.+)\z/
+    opts[:out] = Regexp.last_match(1)
+  when "--root"
+    opts[:root] = Pathname.new(ARGV[i + 1])
+    i += 1
+  when "--help", "-h"
+    # Read with explicit UTF-8 encoding so non-ASCII chars in this header
+    # (em-dashes etc.) don't trip a US-ASCII default locale.
+    puts File.read(__FILE__, encoding: "UTF-8").lines.grep(/^# /).join
+    exit 0
+  else
+    warn "ERROR: unknown flag '#{arg}' — see --help"
+    exit 2
+  end
+  i += 1
+end
+
+unless %w[yaml csv].include?(opts[:format])
+  warn "ERROR: --format must be 'yaml' or 'csv'"
+  exit 2
+end
+
+ROOT = opts[:root]
+
+# -- Helpers -------------------------------------------------------------------
+
+def type_guess(path, ext)
+  basename = File.basename(path).downcase
+  path_str = path.to_s.downcase
+
+  return "gif"      if ext == "gif"
+  return "pdf"      if PDF_EXTS.include?(ext)
+  return "video"    if VIDEO_EXTS.include?(ext)
+  return "headshot" if path_str.match?(%r{/team/|headshot}) && IMAGE_EXTS.include?(ext)
+  return "logo"     if basename.match?(/logo/) || path_str.match?(%r{/logos?/})
+  return "diagram"  if ext == "svg" && !path_str.match?(%r{/logos?/})
+  return "hero"     if basename.match?(/hero/) || path_str.match?(%r{/projects/[^/]+/hero})
+  return "screenshot" if basename.match?(/screenshot|screencap|capture/) ||
+                        path_str.match?(%r{/screenshots?/|/reference/images/})
+  return "photo"    if IMAGE_EXTS.include?(ext)
+
+  "unknown"
+end
+
+def load_manifests(root)
+  index = {} # repo-relative path → manifest path
+  Dir.glob(root.join("**/{assets-manifest,image-library}.yml")).each do |path|
+    next if path.include?("/node_modules/")
+    data =
+      begin
+        YAML.load_file(path)
+      rescue StandardError
+        next
+      end
+    entries =
+      if data.is_a?(Array)
+        data
+      elsif data.is_a?(Hash) && data["images"]
+        data["images"]
+      elsif data.is_a?(Hash) && data["assets"]
+        data["assets"]
+      else
+        []
+      end
+    next if entries.nil?
+
+    manifest_dir = Pathname.new(path).dirname
+    entries.each do |entry|
+      next unless entry.is_a?(Hash) && entry["path"]
+      resolved = manifest_dir.join(entry["path"]).cleanpath
+      rel = resolved.relative_path_from(root).to_s
+      index[rel] = path
+    end
+  end
+  index
+end
+
+# -- Main ----------------------------------------------------------------------
+
+manifest_index = load_manifests(ROOT)
+
+ignore_dir_regex = Regexp.union(
+  %r{/\.git/},
+  %r{/node_modules/},
+  %r{/vendor/bundle/},
+  %r{/_site/},
+  %r{/build/},
+  %r{/dist/},
+)
+
+rows = []
+ALL_EXTS.each do |ext|
+  Dir.glob(ROOT.join("**", "*.#{ext}"), File::FNM_CASEFOLD).each do |file|
+    next if file.match?(ignore_dir_regex)
+    p = Pathname.new(file)
+    next unless p.file?
+
+    rel = p.relative_path_from(ROOT).to_s
+    stat = p.stat
+    rows << {
+      "path"          => rel,
+      "size_bytes"    => stat.size,
+      "ext"           => ext.downcase,
+      "type_guess"    => type_guess(p, ext.downcase),
+      "in_manifest"   => manifest_index.key?(rel),
+      "manifest_path" => manifest_index[rel] && Pathname.new(manifest_index[rel]).relative_path_from(ROOT).to_s,
+      "archived_dir"  => rel.split("/").include?("_archived"),
+      "incoming_dir"  => rel.split("/").include?("_incoming"),
+    }
+  end
+end
+
+rows = rows.uniq { |r| r["path"] }.sort_by { |r| r["path"] }
+
+# -- Emit ----------------------------------------------------------------------
+
+output =
+  case opts[:format]
+  when "yaml"
+    rows.to_yaml
+  when "csv"
+    CSV.generate do |csv|
+      next if rows.empty?
+      csv << rows.first.keys
+      rows.each { |r| csv << r.values }
+    end
+  end
+
+if opts[:out]
+  File.write(opts[:out], output)
+  warn "wrote #{rows.size} row(s) to #{opts[:out]}"
+else
+  print output
+  warn "scanned #{rows.size} asset(s) under #{ROOT}"
+end
+
+exit 0

--- a/standards/asset-manifest-schema.yml
+++ b/standards/asset-manifest-schema.yml
@@ -1,0 +1,222 @@
+# Federation asset registry — manifest schema.
+#
+# Machine-parseable schema for per-repo asset manifests
+# (assets-manifest.yml, image-library.yml, etc.) across the Skylight
+# federation. Consumed by scripts/check_asset_manifests.rb (per-repo
+# validator) and scripts/render_asset_index.rb (federation aggregator).
+#
+# This is JSON Schema (draft-07) expressed as YAML. The validator
+# hand-rolls the checks for clearer error messages but reads required-
+# field + enum + pattern constraints from here so they stay co-located
+# with the schema spec.
+#
+# Source proposal: plans/active/federation-asset-registry.md
+# Source migration: migrations/federation-asset-registry-bootstrap.md
+# Narrative explainer: standards/asset-manifests.md
+
+$schema: https://json-schema.org/draft-07/schema#
+title: Asset manifest entry
+description: |
+  One entry in a federation asset manifest. Storage stays local to the
+  repo holding the asset; this schema enforces that every committed
+  image has a manifest row and that vocab fields reference the
+  controlled vocabulary in standards/asset-vocabulary.yml.
+
+type: object
+
+required:
+  - id
+  - path
+  - repo
+  - date
+  - type
+  - permissions
+  - classification
+  - archived
+  - pending_classification
+
+properties:
+
+  id:
+    type: string
+    description: Stable kebab-case identifier; unique within its manifest.
+    pattern: "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+
+  path:
+    type: string
+    description: Repo-relative path to the asset file.
+    pattern: "^[^/].*[^/]$"
+
+  repo:
+    type: string
+    description: Federation member that holds the asset.
+    enum:
+      - skylight-hub
+      - skylight.digital
+      - skylight-marcom
+      - skylight-people-ops
+      - skylight-hub-proposals-resolve
+
+  date:
+    type: string
+    description: Capture date (EXIF or human-known), ISO YYYY-MM-DD.
+    pattern: "^\\d{4}-\\d{2}-\\d{2}$"
+
+  type:
+    type: string
+    description: Asset kind. Controlled by standards/asset-vocabulary.yml.
+    # Enum mirrored from asset-vocabulary.yml `type:` key.
+    enum:
+      - photo
+      - screenshot
+      - diagram
+      - logo
+      - headshot
+      - hero
+      - gif
+      - video
+      - pdf
+      - illustration
+      - composite
+
+  themes:
+    type: array
+    items:
+      type: string
+    description: |
+      References standards/asset-vocabulary.yml `themes:` top-level key.
+      Validated for vocab compliance by check_asset_manifests.rb.
+
+  tags:
+    type: array
+    items:
+      type: string
+    description: |
+      References standards/asset-vocabulary.yml `tags:` top-level key.
+      Open-ended; validator warns on unknown tags rather than fails so
+      vocab evolves naturally.
+
+  people:
+    type: array
+    items:
+      type: string
+    description: |
+      Canonical skylighter slugs. Cross-referenced against
+      skylight.digital/_data/team.yml (or equivalent) when available.
+
+  event:
+    type: ["string", "null"]
+    description: Event slug or null. Free-form initially; may graduate to enum.
+
+  alt:
+    type: string
+    description: |
+      Screen-reader-optimized alt text. ≤125 chars recommended.
+      Mandatory for non-decorative images. Animated content describes
+      what changes, not what's there.
+    maxLength: 250
+
+  description:
+    type: string
+    description: |
+      Discovery + search prose. Free-form paragraph(s) covering:
+      (1) visible content, (2) context (when/where/why), (3) use
+      suggestions. Drives both human browsing and asset-finder
+      agent queries.
+
+  permissions:
+    type: string
+    description: |
+      Rights tier. Controls which surfaces an image can ship to.
+    enum:
+      - skylight-owned
+      - partner-owned
+      - nda-bound
+      - public-domain
+      - review-needed
+
+  classification:
+    type: string
+    description: |
+      Access tier. Public images can ship to public posts; client-
+      confidential ones cannot.
+    enum:
+      - public
+      - internal
+      - client-confidential
+
+  set_id:
+    type: ["string", "null"]
+    description: |
+      Groups multiple shots of the same subject. Agents pick a
+      representative when surfacing image suggestions. Must be null
+      while pending_classification: true.
+
+  used_in:
+    type: array
+    items:
+      type: string
+    description: |
+      Cross-references — post IDs, case-study slugs, doc slugs,
+      proposal slugs. Resolution checked by the federation aggregator.
+
+  archived:
+    type: boolean
+    description: |
+      True if retired from active use. Archived assets stay queryable
+      with --include-archived but are excluded from default agent
+      suggestions. See archive lifecycle in proposal.
+
+  archived_at:
+    type: ["string", "null"]
+    description: |
+      Required when archived: true. ISO YYYY-MM-DD.
+    pattern: "^\\d{4}-\\d{2}-\\d{2}$"
+
+  archived_reason:
+    type: ["string", "null"]
+    description: |
+      Required when archived: true. References asset-vocabulary.yml
+      `archive_reasons:` key.
+
+  pending_classification:
+    type: boolean
+    description: |
+      True while staged in _incoming/ awaiting triage. Excludes from
+      agent suggestions. Mutually exclusive with archived: true.
+
+  landed_at:
+    type: ["string", "null"]
+    description: |
+      Required when pending_classification: true. ISO YYYY-MM-DD.
+    pattern: "^\\d{4}-\\d{2}-\\d{2}$"
+
+  landed_via:
+    type: ["string", "null"]
+    description: |
+      Required when pending_classification: true. References
+      asset-vocabulary.yml `landed_via:` key.
+
+  moved_to:
+    type: ["string", "null"]
+    description: |
+      Pointer to destination after cross-repo route: <repo>/<path>.
+      Set on the source-repo row; the destination repo gets a new
+      active row. Validator checks for matching destination.
+
+  notes:
+    type: ["string", "null"]
+    description: Free-text notes.
+
+# -- Cross-field rules (enforced by validator, not pure JSON Schema)
+#
+# 1. archived: true ⟹ archived_at + archived_reason both present
+# 2. pending_classification: true ⟹ landed_at + landed_via both present
+# 3. pending_classification: true ⟹ set_id: null AND used_in: []
+# 4. archived: true AND pending_classification: true ⟹ ERROR (mutually exclusive)
+# 5. moved_to is set ⟹ archived: true (the source row archives when routed away)
+# 6. permissions: review-needed AND archived: false ⟹ WARN (long-pending review-needed
+#    rows should be downgraded or archived)
+#
+# These are documented here for spec completeness; check_asset_manifests.rb
+# implements them.

--- a/standards/asset-vocabulary.yml
+++ b/standards/asset-vocabulary.yml
@@ -1,0 +1,160 @@
+# Federation asset registry — controlled vocabulary.
+#
+# Canonical lists for the fields in asset manifests across the Skylight
+# federation. Per-repo manifests (assets-manifest.yml, image-library.yml)
+# reference these lists; the validator (scripts/check_asset_manifests.rb)
+# enforces compliance.
+#
+# Vocab evolves through hub PRs:
+#   1. Open PR adding a new entry here with rationale in the PR description
+#   2. Linter rule lands the new entry in any per-repo manifest using it
+#   3. Aggregator picks up the change on next run
+#
+# Source proposal: plans/active/federation-asset-registry.md
+# Source migration: migrations/federation-asset-registry-bootstrap.md
+
+# -- Asset types (enum; validator fails on unknown values) --------------------
+
+type:
+  - photo
+  - screenshot
+  - diagram
+  - logo
+  - headshot
+  - hero
+  - gif
+  - video
+  - pdf
+  - illustration
+  - composite
+
+# -- Permissions tier (enum) --------------------------------------------------
+
+permissions:
+  - skylight-owned         # Captured by Skylight or work-for-hire; Skylight has full rights.
+  - partner-owned          # Partner-provided; usage governed by partner's terms.
+  - nda-bound              # Restricted access; cannot ship to public surfaces.
+  - public-domain          # Truly public (Creative Commons CC0, US gov work, etc.).
+  - review-needed          # Rights situation unclear; review before reuse. Long-pending
+                           # rows should be downgraded or archived; aggregator warns.
+
+# -- Classification tier (enum) -----------------------------------------------
+
+classification:
+  - public                 # OK on public surfaces (LinkedIn, public website, public docs).
+  - internal               # Internal-only — Skylighter Slack, internal wiki, but not public.
+  - client-confidential    # Client-NDA-bound; only routable within per-client marketplace.
+
+# -- Archive reasons (enum; required when archived: true) ---------------------
+
+archive_reasons:
+  - outdated-branding              # Old logo / visual identity / color palette
+  - person-no-longer-at-skylight   # Subject left the company
+  - partner-relationship-ended     # Partner org no longer engaged
+  - event-canceled-or-retracted    # Event we promoted no longer worth referencing
+  - legal-or-permissions-issue     # Rights problem; cannot be re-used
+  - low-quality                    # Better alternatives exist; redundant or technically poor
+  - superseded-by-better-shot      # Used to be canonical; better image now is (link via set_id)
+  - content-no-longer-accurate     # Documents something that's changed (org, product UI, etc.)
+  - dedup-loser                    # Identified as near-duplicate; canonical version won
+  - routed-out                     # Source-repo marker after cross-repo route_asset move
+
+# -- Incoming landed_via codes (enum; required when pending_classification: true) ---
+
+landed_via:
+  - ad-hoc-upload          # Dropped in directly without a destination call
+  - gdrive-import          # Pulled via import_gdrive_assets.rb; auto-classification failed
+  - screenshot-collection  # Swept from a contributor's screenshot folder
+  - external-receipt       # Received from partner / client / event organizer
+  - unknown                # No provenance data
+
+# -- Themes (open vocab; validator warns on unknown values) -------------------
+#
+# Themes describe the post / doc / channel context the asset fits — what
+# kind of surface it's used on. Drawn from the channel-writer plugins'
+# post-themes / content-themes vocabs. Open-ended so new themes can land
+# in per-channel overlays without a hub PR; validator warns rather than
+# fails on unknown values.
+
+themes:
+  # -- Social post themes (mirror skylight-marcom/plugins/skylight-social-post-content-overlay/content/post-themes.yml)
+  - contract-win
+  - recruiting
+  - news
+  - new-hire-spotlight
+  - case-study
+  - partner-highlight
+  - company-culture-highlight
+  - delivery-highlight
+  - evergreen
+  - content-farming
+  # -- Documentation themes
+  - methodology            # Diagrams in standards / methodology docs
+  - architecture           # Architecture diagrams in proposals / specs
+  - process-illustration   # Workflow diagrams in policies / playbooks
+  - brand                  # Logo, color palette, brand-guidelines artifacts
+  - team                   # Team photos, headshots, group shots
+  - office                 # Workspace / event venue / location photos
+  - product                # Product UI screenshots, GIFs, hero shots
+
+# -- Tags (open vocab; validator warns on unknown values) ---------------------
+#
+# Tags describe the asset's subject — what's in it. Free-form by design,
+# but common tags should be reused. Validator warns on unknown values
+# so the vocab evolves naturally.
+
+tags:
+  # -- Customer / partner names (controlled — these get social mentions)
+  - cdc
+  - va
+  - usaf
+  - hhs
+  - cms
+  - ct                     # Connecticut state-level engagements
+  - 18f
+  - platform-one
+  # -- Mission areas (mirror skylight-website-filters-pack:filters.yml mission_areas)
+  - public-health
+  - healthcare
+  - early-childhood
+  - veterans
+  - social-safety-net
+  - economic-development
+  - defense
+  - air-force
+  - space-force
+  - navy
+  - homeland-security
+  - citizenship-and-immigration
+  - labor
+  - agriculture
+  - education
+  - environment
+  - justice
+  # -- Capability tags (mirror filters.yml capabilities; kebab-case)
+  - research-and-design
+  - product-management
+  - software-delivery
+  - legacy-modernization
+  - devops
+  - cloud-and-platforms
+  - data-and-analytics
+  - apis
+  - open-government
+  - security-and-privacy
+  - internet-of-things
+  - procurement
+  - transformation
+  - coaching-and-training
+  # -- Project / engagement codenames (extend as case studies land)
+  - gearfit
+  - bespin
+  - dibbs
+  - simplereport
+  - diffusion-marketplace
+  - oec-website-redesign
+  - ece-reporter
+  # -- Event / venue tags
+  - bes-agile-crosstalk
+  - civic-tech-week
+  - code-for-america-summit


### PR DESCRIPTION
**Phase C.1** of the federation asset registry — the first skylight.digital bootstrap. Catalogs `img/brand` (113 brand identity assets) and stands up the per-repo tooling so the manifest validates here.

## What's in it
- **`img/brand/assets-manifest.yml`** — 113 entries: 38 logos/halo marks, 45 illustrations (hero page-headers + illustration examples), 20 photos, 10 diagrams (color/typography samples). All Skylight's own assets on the public site → `permissions: skylight-owned`, `classification: public`, `themes: [brand]`.
- **Per-repo tooling + canon** copied from skylight-hub: `scripts/{check_asset_manifests,scan_assets,scaffold_asset_manifest}.rb` + `standards/asset-{manifest-schema,vocabulary}.yml`. `scripts/` + `standards/` excluded from the Jekyll build (`_config.yml`).
- **`.github/workflows/asset-manifests.yml`** — CI gate (mirrors the hub's validator job).

## 👀 Review notes (the judgment fields)
- `skylight-owned` / `public` / `brand` are uniform across all 113 — they're Skylight's own public brand assets. Flag any exceptions.
- **Precise** alt/descriptions for the known logo/halo marks; **path-derived** descriptions for the ~75 hero-illustration / swatch / example assets (accurate to each asset's role in the brand library, but your team may want to refine the abstract ones).
- **ids are path-based** to disambiguate from the hub's brand-pack manifest, which vendors a subset of these same logos. Verified: cross-repo aggregation across hub + skylight.digital = **124 assets, 0 id collisions**.

## Scope
This is the brand slice. The rest of skylight.digital (`img/people` 411, `img/projects` 180, `img/blog` 150, …) is **Phase C.2+**, which needs team knowledge (person-IDs, client tags, partner-logo rights). `build/` (~2,000 generated artifacts) is excluded — and is probably worth gitignoring separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)