### PR TITLE
Phase C.2: catalog skylight.digital people / projects / blog (741 assets)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -114,6 +114,9 @@ exclude:
   - lighthouse
   - scripts
   - standards
+  # Federation asset-registry manifests — internal metadata, not site content
+  - "**/assets-manifest.yml"
+  - "**/image-library.yml"
 
 # Plugins & gems
 plugins:

--- a/img/blog/assets-manifest.yml
+++ b/img/blog/assets-manifest.yml
@@ -1,0 +1,2341 @@
+# Federation asset manifest -- skylight.digital img/blog (Phase C.2).
+# Path-derived enrichment; all assets are Skylight's own on the public site
+# -> permissions: skylight-owned, classification: public. ids are path-based.
+# NOTE: judgment fields the team should refine -- which people are current vs.
+# former (archive those), client/mission tags per project, and richer alt text.
+- id: blog-agile-share-in-savings-creative-commons-public-domain
+  path: agile_share_in_savings/creative-commons-public-domain.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - agile-share-in-savings
+  alt: 'Agile Share In Savings blog post: Creative Commons Public Domain'
+  description: Blog graphic for the 'Agile Share In Savings' post (Creative Commons
+    Public Domain).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-agile-share-in-savings-creative-commons-public-domain-2
+  path: agile_share_in_savings/creative-commons-public-domain.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - agile-share-in-savings
+  alt: 'Agile Share In Savings blog post: Creative Commons Public Domain'
+  description: Blog graphic for the 'Agile Share In Savings' post (Creative Commons
+    Public Domain).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-api-enablement-api-enablement
+  path: api_enablement/api-enablement.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - api-enablement
+  alt: 'Api Enablement blog post: Api Enablement'
+  description: Blog graphic for the 'Api Enablement' post (Api Enablement).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-api-enablement-api-enablement-2
+  path: api_enablement/api-enablement.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - api-enablement
+  alt: 'Api Enablement blog post: Api Enablement'
+  description: Blog graphic for the 'Api Enablement' post (Api Enablement).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-bug-bounty-solution-announcement-bug-bounty-services
+  path: bug_bounty_solution_announcement/bug-bounty-services.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - bug-bounty-solution-announcement
+  alt: 'Bug Bounty Solution Announcement blog post: Bug Bounty Services'
+  description: Blog graphic for the 'Bug Bounty Solution Announcement' post (Bug Bounty
+    Services).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-bug-bounty-solution-announcement-bug-bounty-services-2
+  path: bug_bounty_solution_announcement/bug-bounty-services.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - bug-bounty-solution-announcement
+  alt: 'Bug Bounty Solution Announcement blog post: Bug Bounty Services'
+  description: Blog graphic for the 'Bug Bounty Solution Announcement' post (Bug Bounty
+    Services).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-bug-bounty-solution-announcement-bugs-eating-computer
+  path: bug_bounty_solution_announcement/bugs-eating-computer.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - bug-bounty-solution-announcement
+  alt: 'Bug Bounty Solution Announcement blog post: Bugs Eating Computer'
+  description: Blog graphic for the 'Bug Bounty Solution Announcement' post (Bugs
+    Eating Computer).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-bug-bounty-solution-announcement-bugs-eating-computer-2
+  path: bug_bounty_solution_announcement/bugs-eating-computer.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - bug-bounty-solution-announcement
+  alt: 'Bug Bounty Solution Announcement blog post: Bugs Eating Computer'
+  description: Blog graphic for the 'Bug Bounty Solution Announcement' post (Bugs
+    Eating Computer).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-case-management-case-management-system-diagram
+  path: case_management/case-management-system-diagram.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes: []
+  tags: []
+  used_in:
+  - case-management
+  alt: 'Case Management blog post: Case Management System Diagram'
+  description: Blog graphic for the 'Case Management' post (Case Management System
+    Diagram).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-case-management-case-management-system-diagram-2
+  path: case_management/case-management-system-diagram.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes: []
+  tags: []
+  used_in:
+  - case-management
+  alt: 'Case Management blog post: Case Management System Diagram'
+  description: Blog graphic for the 'Case Management' post (Case Management System
+    Diagram).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-case-management-paper-case-files-pile
+  path: case_management/paper-case-files-pile.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - case-management
+  alt: 'Case Management blog post: Paper Case Files Pile'
+  description: Blog graphic for the 'Case Management' post (Paper Case Files Pile).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-case-management-paper-case-files-pile-2
+  path: case_management/paper-case-files-pile.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - case-management
+  alt: 'Case Management blog post: Paper Case Files Pile'
+  description: Blog graphic for the 'Case Management' post (Paper Case Files Pile).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-charlye-tran-interview-charlye-tran
+  path: charlye_tran_interview/charlye-tran.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - charlye-tran-interview
+  alt: 'Charlye Tran Interview blog post: Charlye Tran'
+  description: Blog graphic for the 'Charlye Tran Interview' post (Charlye Tran).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-charlye-tran-interview-charlye-tran-2
+  path: charlye_tran_interview/charlye-tran.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - charlye-tran-interview
+  alt: 'Charlye Tran Interview blog post: Charlye Tran'
+  description: Blog graphic for the 'Charlye Tran Interview' post (Charlye Tran).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-containers-thinking-inside-the-box-containers
+  path: containers_thinking_inside_the_box/containers.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - containers-thinking-inside-the-box
+  alt: 'Containers Thinking Inside The Box blog post: Containers'
+  description: Blog graphic for the 'Containers Thinking Inside The Box' post (Containers).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-containers-thinking-inside-the-box-containers-2
+  path: containers_thinking_inside_the_box/containers.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - containers-thinking-inside-the-box
+  alt: 'Containers Thinking Inside The Box blog post: Containers'
+  description: Blog graphic for the 'Containers Thinking Inside The Box' post (Containers).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-containers-thinking-inside-the-box-virtual-machines-vs-containers
+  path: containers_thinking_inside_the_box/virtual-machines-vs-containers.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - containers-thinking-inside-the-box
+  alt: 'Containers Thinking Inside The Box blog post: Virtual Machines Vs Containers'
+  description: Blog graphic for the 'Containers Thinking Inside The Box' post (Virtual
+    Machines Vs Containers).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-containers-thinking-inside-the-box-virtual-machines-vs-containers-2
+  path: containers_thinking_inside_the_box/virtual-machines-vs-containers.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - containers-thinking-inside-the-box
+  alt: 'Containers Thinking Inside The Box blog post: Virtual Machines Vs Containers'
+  description: Blog graphic for the 'Containers Thinking Inside The Box' post (Virtual
+    Machines Vs Containers).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-cool-kids-cool-person
+  path: cool_kids/cool-person.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - cool-kids
+  alt: 'Cool Kids blog post: Cool Person'
+  description: Blog graphic for the 'Cool Kids' post (Cool Person).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-cool-kids-cool-person-2
+  path: cool_kids/cool-person.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - cool-kids
+  alt: 'Cool Kids blog post: Cool Person'
+  description: Blog graphic for the 'Cool Kids' post (Cool Person).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-darpa-proposal-story-dense-sense-infographic
+  path: darpa_proposal_story/dense-sense-infographic.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - darpa-proposal-story
+  alt: 'Darpa Proposal Story blog post: Dense Sense Infographic'
+  description: Blog graphic for the 'Darpa Proposal Story' post (Dense Sense Infographic).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-darpa-proposal-story-dense-sense-infographic-2
+  path: darpa_proposal_story/dense-sense-infographic.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - darpa-proposal-story
+  alt: 'Darpa Proposal Story blog post: Dense Sense Infographic'
+  description: Blog graphic for the 'Darpa Proposal Story' post (Dense Sense Infographic).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-darpa-proposal-story-dense-sense
+  path: darpa_proposal_story/dense-sense.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - darpa-proposal-story
+  alt: 'Darpa Proposal Story blog post: Dense Sense'
+  description: Blog graphic for the 'Darpa Proposal Story' post (Dense Sense).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-darpa-proposal-story-dense-sense-2
+  path: darpa_proposal_story/dense-sense.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - darpa-proposal-story
+  alt: 'Darpa Proposal Story blog post: Dense Sense'
+  description: Blog graphic for the 'Darpa Proposal Story' post (Dense Sense).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-devops-transformation-proposal-acme-engagement-phases
+  path: devops_transformation_proposal/acme-engagement-phases.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - devops-transformation-proposal
+  alt: 'Devops Transformation Proposal blog post: Acme Engagement Phases'
+  description: Blog graphic for the 'Devops Transformation Proposal' post (Acme Engagement
+    Phases).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-devops-transformation-proposal-acme-engagement-phases-2
+  path: devops_transformation_proposal/acme-engagement-phases.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - devops-transformation-proposal
+  alt: 'Devops Transformation Proposal blog post: Acme Engagement Phases'
+  description: Blog graphic for the 'Devops Transformation Proposal' post (Acme Engagement
+    Phases).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-devops-transformation-proposal-devops-contract
+  path: devops_transformation_proposal/devops-contract.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - devops-transformation-proposal
+  alt: 'Devops Transformation Proposal blog post: Devops Contract'
+  description: Blog graphic for the 'Devops Transformation Proposal' post (Devops
+    Contract).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-devops-transformation-proposal-devops-contract-2
+  path: devops_transformation_proposal/devops-contract.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - devops-transformation-proposal
+  alt: 'Devops Transformation Proposal blog post: Devops Contract'
+  description: Blog graphic for the 'Devops Transformation Proposal' post (Devops
+    Contract).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-dora-devops
+  path: dora/devops.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - dora
+  alt: 'Dora blog post: Devops'
+  description: Blog graphic for the 'Dora' post (Devops).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-dora-devops-2
+  path: dora/devops.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - dora
+  alt: 'Dora blog post: Devops'
+  description: Blog graphic for the 'Dora' post (Devops).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-dora-dora-infographic
+  path: dora/dora-infographic.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - dora
+  alt: 'Dora blog post: Dora Infographic'
+  description: Blog graphic for the 'Dora' post (Dora Infographic).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-dora-dora-infographic-2
+  path: dora/dora-infographic.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - dora
+  alt: 'Dora blog post: Dora Infographic'
+  description: Blog graphic for the 'Dora' post (Dora Infographic).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-early-childhood-info-systems-insights-early-care-and-education-service-delivery-flow
+  path: early_childhood_info_systems_insights/early-care-and-education-service-delivery-flow.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes: []
+  tags: []
+  used_in:
+  - early-childhood-info-systems-insights
+  alt: 'Early Childhood Info Systems Insights blog post: Early Care And Education
+    Service Delivery Flow'
+  description: Blog graphic for the 'Early Childhood Info Systems Insights' post (Early
+    Care And Education Service Delivery Flow).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-early-childhood-info-systems-insights-early-care-and-education-service-delivery-flow-2
+  path: early_childhood_info_systems_insights/early-care-and-education-service-delivery-flow.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes: []
+  tags: []
+  used_in:
+  - early-childhood-info-systems-insights
+  alt: 'Early Childhood Info Systems Insights blog post: Early Care And Education
+    Service Delivery Flow'
+  description: Blog graphic for the 'Early Childhood Info Systems Insights' post (Early
+    Care And Education Service Delivery Flow).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-early-childhood-info-systems-insights-families-with-young-children-map
+  path: early_childhood_info_systems_insights/families-with-young-children-map.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - early-childhood-info-systems-insights
+  alt: 'Early Childhood Info Systems Insights blog post: Families With Young Children
+    Map'
+  description: Blog graphic for the 'Early Childhood Info Systems Insights' post (Families
+    With Young Children Map).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-early-childhood-info-systems-insights-families-with-young-children-map-2
+  path: early_childhood_info_systems_insights/families-with-young-children-map.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - early-childhood-info-systems-insights
+  alt: 'Early Childhood Info Systems Insights blog post: Families With Young Children
+    Map'
+  description: Blog graphic for the 'Early Childhood Info Systems Insights' post (Families
+    With Young Children Map).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-federal-cio-digital-transformation-principles-cio-digital-world
+  path: federal_cio_digital_transformation_principles/cio-digital-world.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - federal-cio-digital-transformation-principles
+  alt: 'Federal Cio Digital Transformation Principles blog post: Cio Digital World'
+  description: Blog graphic for the 'Federal Cio Digital Transformation Principles'
+    post (Cio Digital World).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-federal-cio-digital-transformation-principles-cio-digital-world-2
+  path: federal_cio_digital_transformation_principles/cio-digital-world.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - federal-cio-digital-transformation-principles
+  alt: 'Federal Cio Digital Transformation Principles blog post: Cio Digital World'
+  description: Blog graphic for the 'Federal Cio Digital Transformation Principles'
+    post (Cio Digital World).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-federal-cio-digital-transformation-principles-digital-transformation-framework
+  path: federal_cio_digital_transformation_principles/digital-transformation-framework.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes: []
+  tags: []
+  used_in:
+  - federal-cio-digital-transformation-principles
+  alt: 'Federal Cio Digital Transformation Principles blog post: Digital Transformation
+    Framework'
+  description: Blog graphic for the 'Federal Cio Digital Transformation Principles'
+    post (Digital Transformation Framework).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-federal-cio-digital-transformation-principles-digital-transformation-framework-2
+  path: federal_cio_digital_transformation_principles/digital-transformation-framework.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes: []
+  tags: []
+  used_in:
+  - federal-cio-digital-transformation-principles
+  alt: 'Federal Cio Digital Transformation Principles blog post: Digital Transformation
+    Framework'
+  description: Blog graphic for the 'Federal Cio Digital Transformation Principles'
+    post (Digital Transformation Framework).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-five-pifs-join-welcome
+  path: five_pifs_join/welcome.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - five-pifs-join
+  alt: 'Five Pifs Join blog post: Welcome'
+  description: Blog graphic for the 'Five Pifs Join' post (Welcome).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-five-pifs-join-welcome-2
+  path: five_pifs_join/welcome.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - five-pifs-join
+  alt: 'Five Pifs Join blog post: Welcome'
+  description: Blog graphic for the 'Five Pifs Join' post (Welcome).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-geoff-mulligan-interview-geoff-mulligan
+  path: geoff_mulligan_interview/geoff-mulligan.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - geoff-mulligan-interview
+  alt: 'Geoff Mulligan Interview blog post: Geoff Mulligan'
+  description: Blog graphic for the 'Geoff Mulligan Interview' post (Geoff Mulligan).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-geoff-mulligan-interview-geoff-mulligan-2
+  path: geoff_mulligan_interview/geoff-mulligan.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - geoff-mulligan-interview
+  alt: 'Geoff Mulligan Interview blog post: Geoff Mulligan'
+  description: Blog graphic for the 'Geoff Mulligan Interview' post (Geoff Mulligan).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-gianna-buda-interview-gianna-buda
+  path: gianna_buda_interview/gianna-buda.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - gianna-buda-interview
+  alt: 'Gianna Buda Interview blog post: Gianna Buda'
+  description: Blog graphic for the 'Gianna Buda Interview' post (Gianna Buda).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-gianna-buda-interview-gianna-buda-2
+  path: gianna_buda_interview/gianna-buda.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - gianna-buda-interview
+  alt: 'Gianna Buda Interview blog post: Gianna Buda'
+  description: Blog graphic for the 'Gianna Buda Interview' post (Gianna Buda).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-jordan-guinn-interview-jordan-guinn
+  path: jordan_guinn_interview/jordan-guinn.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - jordan-guinn-interview
+  alt: 'Jordan Guinn Interview blog post: Jordan Guinn'
+  description: Blog graphic for the 'Jordan Guinn Interview' post (Jordan Guinn).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-jordan-guinn-interview-jordan-guinn-2
+  path: jordan_guinn_interview/jordan-guinn.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - jordan-guinn-interview
+  alt: 'Jordan Guinn Interview blog post: Jordan Guinn'
+  description: Blog graphic for the 'Jordan Guinn Interview' post (Jordan Guinn).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-josh-dorothy-interview-josh-dorothy
+  path: josh_dorothy_interview/josh-dorothy.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - josh-dorothy-interview
+  alt: 'Josh Dorothy Interview blog post: Josh Dorothy'
+  description: Blog graphic for the 'Josh Dorothy Interview' post (Josh Dorothy).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-josh-dorothy-interview-josh-dorothy-2
+  path: josh_dorothy_interview/josh-dorothy.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - josh-dorothy-interview
+  alt: 'Josh Dorothy Interview blog post: Josh Dorothy'
+  description: Blog graphic for the 'Josh Dorothy Interview' post (Josh Dorothy).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-kin-lane-interview-kin-lane
+  path: kin_lane_interview/kin-lane.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - kin-lane-interview
+  alt: 'Kin Lane Interview blog post: Kin Lane'
+  description: Blog graphic for the 'Kin Lane Interview' post (Kin Lane).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-kin-lane-interview-kin-lane-2
+  path: kin_lane_interview/kin-lane.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - kin-lane-interview
+  alt: 'Kin Lane Interview blog post: Kin Lane'
+  description: Blog graphic for the 'Kin Lane Interview' post (Kin Lane).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-agile-software-development-process
+  path: lean_software_development/agile-software-development-process.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Agile Software Development Process'
+  description: Blog graphic for the 'Lean Software Development' post (Agile Software
+    Development Process).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-agile-software-development-process-2
+  path: lean_software_development/agile-software-development-process.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Agile Software Development Process'
+  description: Blog graphic for the 'Lean Software Development' post (Agile Software
+    Development Process).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-crossroads
+  path: lean_software_development/crossroads.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Crossroads'
+  description: Blog graphic for the 'Lean Software Development' post (Crossroads).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-crossroads-2
+  path: lean_software_development/crossroads.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Crossroads'
+  description: Blog graphic for the 'Lean Software Development' post (Crossroads).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-lean-agile-matrix
+  path: lean_software_development/lean-agile-matrix.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Lean Agile Matrix'
+  description: Blog graphic for the 'Lean Software Development' post (Lean Agile Matrix).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-lean-agile-matrix-2
+  path: lean_software_development/lean-agile-matrix.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Lean Agile Matrix'
+  description: Blog graphic for the 'Lean Software Development' post (Lean Agile Matrix).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-lean-agile-spectrum
+  path: lean_software_development/lean-agile-spectrum.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Lean Agile Spectrum'
+  description: Blog graphic for the 'Lean Software Development' post (Lean Agile Spectrum).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-lean-agile-spectrum-2
+  path: lean_software_development/lean-agile-spectrum.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Lean Agile Spectrum'
+  description: Blog graphic for the 'Lean Software Development' post (Lean Agile Spectrum).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-lean-software-development-video
+  path: lean_software_development/lean-software-development-video.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Lean Software Development Video'
+  description: Blog graphic for the 'Lean Software Development' post (Lean Software
+    Development Video).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-lean-vs-agile
+  path: lean_software_development/lean-vs-agile.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Lean Vs Agile'
+  description: Blog graphic for the 'Lean Software Development' post (Lean Vs Agile).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-lean-vs-agile-2
+  path: lean_software_development/lean-vs-agile.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Lean Vs Agile'
+  description: Blog graphic for the 'Lean Software Development' post (Lean Vs Agile).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-mobile-phone-map-navigation
+  path: lean_software_development/mobile-phone-map-navigation.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Mobile Phone Map Navigation'
+  description: Blog graphic for the 'Lean Software Development' post (Mobile Phone
+    Map Navigation).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-mobile-phone-map-navigation-2
+  path: lean_software_development/mobile-phone-map-navigation.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Mobile Phone Map Navigation'
+  description: Blog graphic for the 'Lean Software Development' post (Mobile Phone
+    Map Navigation).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-software-dev-seven-wastes
+  path: lean_software_development/software-dev-seven-wastes.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Software Dev Seven Wastes'
+  description: Blog graphic for the 'Lean Software Development' post (Software Dev
+    Seven Wastes).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-software-dev-seven-wastes-2
+  path: lean_software_development/software-dev-seven-wastes.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Software Dev Seven Wastes'
+  description: Blog graphic for the 'Lean Software Development' post (Software Dev
+    Seven Wastes).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-starting-point
+  path: lean_software_development/starting-point.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Starting Point'
+  description: Blog graphic for the 'Lean Software Development' post (Starting Point).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-starting-point-2
+  path: lean_software_development/starting-point.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Starting Point'
+  description: Blog graphic for the 'Lean Software Development' post (Starting Point).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-waterfall-development-process
+  path: lean_software_development/waterfall-development-process.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Waterfall Development Process'
+  description: Blog graphic for the 'Lean Software Development' post (Waterfall Development
+    Process).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-waterfall-development-process-2
+  path: lean_software_development/waterfall-development-process.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Waterfall Development Process'
+  description: Blog graphic for the 'Lean Software Development' post (Waterfall Development
+    Process).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-wip-restriction-illustrated
+  path: lean_software_development/wip-restriction-illustrated.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Wip Restriction Illustrated'
+  description: Blog graphic for the 'Lean Software Development' post (Wip Restriction
+    Illustrated).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-lean-software-development-wip-restriction-illustrated-2
+  path: lean_software_development/wip-restriction-illustrated.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - lean-software-development
+  alt: 'Lean Software Development blog post: Wip Restriction Illustrated'
+  description: Blog graphic for the 'Lean Software Development' post (Wip Restriction
+    Illustrated).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-maya-benari-interview-maya-benari
+  path: maya_benari_interview/maya-benari.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - maya-benari-interview
+  alt: 'Maya Benari Interview blog post: Maya Benari'
+  description: Blog graphic for the 'Maya Benari Interview' post (Maya Benari).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-maya-benari-interview-maya-benari-2
+  path: maya_benari_interview/maya-benari.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - maya-benari-interview
+  alt: 'Maya Benari Interview blog post: Maya Benari'
+  description: Blog graphic for the 'Maya Benari Interview' post (Maya Benari).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-meet-ten-newest-team-members-team-member-welcome
+  path: meet_ten_newest_team_members/team-member-welcome.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - meet-ten-newest-team-members
+  alt: 'Meet Ten Newest Team Members blog post: Team Member Welcome'
+  description: Blog graphic for the 'Meet Ten Newest Team Members' post (Team Member
+    Welcome).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-meet-ten-newest-team-members-team-member-welcome-2
+  path: meet_ten_newest_team_members/team-member-welcome.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - meet-ten-newest-team-members
+  alt: 'Meet Ten Newest Team Members blog post: Team Member Welcome'
+  description: Blog graphic for the 'Meet Ten Newest Team Members' post (Team Member
+    Welcome).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-mentor-protege-search-mentor-protege
+  path: mentor_protege_search/mentor-protege.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - mentor-protege-search
+  alt: 'Mentor Protege Search blog post: Mentor Protege'
+  description: Blog graphic for the 'Mentor Protege Search' post (Mentor Protege).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-mentor-protege-search-mentor-protege-2
+  path: mentor_protege_search/mentor-protege.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - mentor-protege-search
+  alt: 'Mentor Protege Search blog post: Mentor Protege'
+  description: Blog graphic for the 'Mentor Protege Search' post (Mentor Protege).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-microconsulting-services-microconsulting
+  path: microconsulting_services/microconsulting.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - microconsulting-services
+  alt: 'Microconsulting Services blog post: Microconsulting'
+  description: Blog graphic for the 'Microconsulting Services' post (Microconsulting).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-microconsulting-services-microconsulting-2
+  path: microconsulting_services/microconsulting.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - microconsulting-services
+  alt: 'Microconsulting Services blog post: Microconsulting'
+  description: Blog graphic for the 'Microconsulting Services' post (Microconsulting).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-microconsulting-unsolicited-proposal-18f-micropurchase-platform-screenshot
+  path: microconsulting_unsolicited_proposal/18f-micropurchase-platform-screenshot.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - microconsulting-unsolicited-proposal
+  alt: 'Microconsulting Unsolicited Proposal blog post: 18f Micropurchase Platform
+    Screenshot'
+  description: Blog graphic for the 'Microconsulting Unsolicited Proposal' post (18f
+    Micropurchase Platform Screenshot).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-microconsulting-unsolicited-proposal-codementor-screenshot
+  path: microconsulting_unsolicited_proposal/codementor-screenshot.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - microconsulting-unsolicited-proposal
+  alt: 'Microconsulting Unsolicited Proposal blog post: Codementor Screenshot'
+  description: Blog graphic for the 'Microconsulting Unsolicited Proposal' post (Codementor
+    Screenshot).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-microconsulting-unsolicited-proposal-microconsulting-services-marketplace-platform-storyboard
+  path: microconsulting_unsolicited_proposal/microconsulting-services-marketplace-platform-storyboard.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - microconsulting-unsolicited-proposal
+  alt: 'Microconsulting Unsolicited Proposal blog post: Microconsulting Services Marketplace
+    Platform Storyboard'
+  description: Blog graphic for the 'Microconsulting Unsolicited Proposal' post (Microconsulting
+    Services Marketplace Platform Storyboard).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-microconsulting-unsolicited-proposal-microconsulting-services-marketplace
+  path: microconsulting_unsolicited_proposal/microconsulting-services-marketplace.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - microconsulting-unsolicited-proposal
+  alt: 'Microconsulting Unsolicited Proposal blog post: Microconsulting Services Marketplace'
+  description: Blog graphic for the 'Microconsulting Unsolicited Proposal' post (Microconsulting
+    Services Marketplace).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-microconsulting-unsolicited-proposal-microconsulting-services-marketplace-2
+  path: microconsulting_unsolicited_proposal/microconsulting-services-marketplace.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - microconsulting-unsolicited-proposal
+  alt: 'Microconsulting Unsolicited Proposal blog post: Microconsulting Services Marketplace'
+  description: Blog graphic for the 'Microconsulting Unsolicited Proposal' post (Microconsulting
+    Services Marketplace).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-mobile-app-dev-trends-mobile-app-dev-trends-1
+  path: mobile_app_dev_trends/mobile-app-dev-trends-1.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - mobile-app-dev-trends
+  alt: 'Mobile App Dev Trends blog post: Mobile App Dev Trends 1'
+  description: Blog graphic for the 'Mobile App Dev Trends' post (Mobile App Dev Trends
+    1).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-mobile-app-dev-trends-mobile-app-dev-trends-1-2
+  path: mobile_app_dev_trends/mobile-app-dev-trends-1.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - mobile-app-dev-trends
+  alt: 'Mobile App Dev Trends blog post: Mobile App Dev Trends 1'
+  description: Blog graphic for the 'Mobile App Dev Trends' post (Mobile App Dev Trends
+    1).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-mobile-app-dev-trends-mobile-app-dev-trends-2
+  path: mobile_app_dev_trends/mobile-app-dev-trends-2.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - mobile-app-dev-trends
+  alt: 'Mobile App Dev Trends blog post: Mobile App Dev Trends 2'
+  description: Blog graphic for the 'Mobile App Dev Trends' post (Mobile App Dev Trends
+    2).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-mobile-app-dev-trends-mobile-app-dev-trends-2-2
+  path: mobile_app_dev_trends/mobile-app-dev-trends-2.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - mobile-app-dev-trends
+  alt: 'Mobile App Dev Trends blog post: Mobile App Dev Trends 2'
+  description: Blog graphic for the 'Mobile App Dev Trends' post (Mobile App Dev Trends
+    2).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-mobile-app-dev-trends-new-multi-mobile-options
+  path: mobile_app_dev_trends/new-multi-mobile-options.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - mobile-app-dev-trends
+  alt: 'Mobile App Dev Trends blog post: New Multi Mobile Options'
+  description: Blog graphic for the 'Mobile App Dev Trends' post (New Multi Mobile
+    Options).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-mobile-app-dev-trends-new-multi-mobile-options-2
+  path: mobile_app_dev_trends/new-multi-mobile-options.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - mobile-app-dev-trends
+  alt: 'Mobile App Dev Trends blog post: New Multi Mobile Options'
+  description: Blog graphic for the 'Mobile App Dev Trends' post (New Multi Mobile
+    Options).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-mobile-app-dev-trends-old-binary-mobile-options
+  path: mobile_app_dev_trends/old-binary-mobile-options.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - mobile-app-dev-trends
+  alt: 'Mobile App Dev Trends blog post: Old Binary Mobile Options'
+  description: Blog graphic for the 'Mobile App Dev Trends' post (Old Binary Mobile
+    Options).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-mobile-app-dev-trends-old-binary-mobile-options-2
+  path: mobile_app_dev_trends/old-binary-mobile-options.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - mobile-app-dev-trends
+  alt: 'Mobile App Dev Trends blog post: Old Binary Mobile Options'
+  description: Blog graphic for the 'Mobile App Dev Trends' post (Old Binary Mobile
+    Options).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-mobile-app-dev-trends-thin-client-thick-api-architecture
+  path: mobile_app_dev_trends/thin-client-thick-api-architecture.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes: []
+  tags: []
+  used_in:
+  - mobile-app-dev-trends
+  alt: 'Mobile App Dev Trends blog post: Thin Client Thick Api Architecture'
+  description: Blog graphic for the 'Mobile App Dev Trends' post (Thin Client Thick
+    Api Architecture).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-mobile-app-dev-trends-thin-client-thick-api-architecture-2
+  path: mobile_app_dev_trends/thin-client-thick-api-architecture.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes: []
+  tags: []
+  used_in:
+  - mobile-app-dev-trends
+  alt: 'Mobile App Dev Trends blog post: Thin Client Thick Api Architecture'
+  description: Blog graphic for the 'Mobile App Dev Trends' post (Thin Client Thick
+    Api Architecture).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-mobile-app-dev-trends-traditional-mobile-architecture
+  path: mobile_app_dev_trends/traditional-mobile-architecture.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes: []
+  tags: []
+  used_in:
+  - mobile-app-dev-trends
+  alt: 'Mobile App Dev Trends blog post: Traditional Mobile Architecture'
+  description: Blog graphic for the 'Mobile App Dev Trends' post (Traditional Mobile
+    Architecture).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-mobile-app-dev-trends-traditional-mobile-architecture-2
+  path: mobile_app_dev_trends/traditional-mobile-architecture.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes: []
+  tags: []
+  used_in:
+  - mobile-app-dev-trends
+  alt: 'Mobile App Dev Trends blog post: Traditional Mobile Architecture'
+  description: Blog graphic for the 'Mobile App Dev Trends' post (Traditional Mobile
+    Architecture).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-nick-bristow-interview-nick-bristow
+  path: nick_bristow_interview/nick-bristow.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - nick-bristow-interview
+  alt: 'Nick Bristow Interview blog post: Nick Bristow'
+  description: Blog graphic for the 'Nick Bristow Interview' post (Nick Bristow).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-nick-bristow-interview-nick-bristow-2
+  path: nick_bristow_interview/nick-bristow.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - nick-bristow-interview
+  alt: 'Nick Bristow Interview blog post: Nick Bristow'
+  description: Blog graphic for the 'Nick Bristow Interview' post (Nick Bristow).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-plain-language-policies-telehealth-plain-language
+  path: plain_language_policies_telehealth/plain-language.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - plain-language-policies-telehealth
+  alt: 'Plain Language Policies Telehealth blog post: Plain Language'
+  description: Blog graphic for the 'Plain Language Policies Telehealth' post (Plain
+    Language).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-plain-language-policies-telehealth-plain-language-2
+  path: plain_language_policies_telehealth/plain-language.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - plain-language-policies-telehealth
+  alt: 'Plain Language Policies Telehealth blog post: Plain Language'
+  description: Blog graphic for the 'Plain Language Policies Telehealth' post (Plain
+    Language).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-plain-language-policies-telehealth-telehealth-billing-codes-prototype
+  path: plain_language_policies_telehealth/telehealth-billing-codes-prototype.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - plain-language-policies-telehealth
+  alt: 'Plain Language Policies Telehealth blog post: Telehealth Billing Codes Prototype'
+  description: Blog graphic for the 'Plain Language Policies Telehealth' post (Telehealth
+    Billing Codes Prototype).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-plain-language-policies-telehealth-telehealth-billing-codes
+  path: plain_language_policies_telehealth/telehealth-billing-codes.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - plain-language-policies-telehealth
+  alt: 'Plain Language Policies Telehealth blog post: Telehealth Billing Codes'
+  description: Blog graphic for the 'Plain Language Policies Telehealth' post (Telehealth
+    Billing Codes).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-power-of-apis-power-of-apis
+  path: power_of_apis/power-of-apis.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - power-of-apis
+  alt: 'Power Of Apis blog post: Power Of Apis'
+  description: Blog graphic for the 'Power Of Apis' post (Power Of Apis).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-power-of-apis-power-of-apis-2
+  path: power_of_apis/power-of-apis.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - power-of-apis
+  alt: 'Power Of Apis blog post: Power Of Apis'
+  description: Blog graphic for the 'Power Of Apis' post (Power Of Apis).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-power-of-apis-risk-utility-graph-with-api
+  path: power_of_apis/risk-utility-graph-with-api.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - power-of-apis
+  alt: 'Power Of Apis blog post: Risk Utility Graph With Api'
+  description: Blog graphic for the 'Power Of Apis' post (Risk Utility Graph With
+    Api).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-power-of-apis-risk-utility-graph-with-api-2
+  path: power_of_apis/risk-utility-graph-with-api.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - power-of-apis
+  alt: 'Power Of Apis blog post: Risk Utility Graph With Api'
+  description: Blog graphic for the 'Power Of Apis' post (Risk Utility Graph With
+    Api).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-power-of-apis-risk-utility-graph-without-api
+  path: power_of_apis/risk-utility-graph-without-api.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - power-of-apis
+  alt: 'Power Of Apis blog post: Risk Utility Graph Without Api'
+  description: Blog graphic for the 'Power Of Apis' post (Risk Utility Graph Without
+    Api).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-power-of-apis-risk-utility-graph-without-api-2
+  path: power_of_apis/risk-utility-graph-without-api.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - power-of-apis
+  alt: 'Power Of Apis blog post: Risk Utility Graph Without Api'
+  description: Blog graphic for the 'Power Of Apis' post (Risk Utility Graph Without
+    Api).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-public-domain-procurement-creative-commons-public-domain
+  path: public_domain_procurement/creative-commons-public-domain.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - public-domain-procurement
+  alt: 'Public Domain Procurement blog post: Creative Commons Public Domain'
+  description: Blog graphic for the 'Public Domain Procurement' post (Creative Commons
+    Public Domain).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-public-domain-procurement-creative-commons-public-domain-2
+  path: public_domain_procurement/creative-commons-public-domain.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - public-domain-procurement
+  alt: 'Public Domain Procurement blog post: Creative Commons Public Domain'
+  description: Blog graphic for the 'Public Domain Procurement' post (Creative Commons
+    Public Domain).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-public-servant-learning-techniques-learning-techniques
+  path: public_servant_learning_techniques/learning-techniques.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - public-servant-learning-techniques
+  alt: 'Public Servant Learning Techniques blog post: Learning Techniques'
+  description: Blog graphic for the 'Public Servant Learning Techniques' post (Learning
+    Techniques).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-public-servant-learning-techniques-learning-techniques-2
+  path: public_servant_learning_techniques/learning-techniques.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - public-servant-learning-techniques
+  alt: 'Public Servant Learning Techniques blog post: Learning Techniques'
+  description: Blog graphic for the 'Public Servant Learning Techniques' post (Learning
+    Techniques).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-puerto-rico-disaster-lab-downed-powerline
+  path: puerto_rico_disaster_lab/downed-powerline.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - puerto-rico-disaster-lab
+  alt: 'Puerto Rico Disaster Lab blog post: Downed Powerline'
+  description: Blog graphic for the 'Puerto Rico Disaster Lab' post (Downed Powerline).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-puerto-rico-disaster-lab-downed-powerline-2
+  path: puerto_rico_disaster_lab/downed-powerline.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - puerto-rico-disaster-lab
+  alt: 'Puerto Rico Disaster Lab blog post: Downed Powerline'
+  description: Blog graphic for the 'Puerto Rico Disaster Lab' post (Downed Powerline).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-puerto-rico-disaster-lab-fast-map
+  path: puerto_rico_disaster_lab/fast-map.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - puerto-rico-disaster-lab
+  alt: 'Puerto Rico Disaster Lab blog post: Fast Map'
+  description: Blog graphic for the 'Puerto Rico Disaster Lab' post (Fast Map).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-puerto-rico-disaster-lab-fast-map-2
+  path: puerto_rico_disaster_lab/fast-map.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - puerto-rico-disaster-lab
+  alt: 'Puerto Rico Disaster Lab blog post: Fast Map'
+  description: Blog graphic for the 'Puerto Rico Disaster Lab' post (Fast Map).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-puerto-rico-disaster-lab-hurricane-maria
+  path: puerto_rico_disaster_lab/hurricane-maria.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - puerto-rico-disaster-lab
+  alt: 'Puerto Rico Disaster Lab blog post: Hurricane Maria'
+  description: Blog graphic for the 'Puerto Rico Disaster Lab' post (Hurricane Maria).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-puerto-rico-disaster-lab-hurricane-maria-2
+  path: puerto_rico_disaster_lab/hurricane-maria.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - puerto-rico-disaster-lab
+  alt: 'Puerto Rico Disaster Lab blog post: Hurricane Maria'
+  description: Blog graphic for the 'Puerto Rico Disaster Lab' post (Hurricane Maria).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-puerto-rico-disaster-lab-landslide
+  path: puerto_rico_disaster_lab/landslide.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - puerto-rico-disaster-lab
+  alt: 'Puerto Rico Disaster Lab blog post: Landslide'
+  description: Blog graphic for the 'Puerto Rico Disaster Lab' post (Landslide).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-puerto-rico-disaster-lab-landslide-2
+  path: puerto_rico_disaster_lab/landslide.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - puerto-rico-disaster-lab
+  alt: 'Puerto Rico Disaster Lab blog post: Landslide'
+  description: Blog graphic for the 'Puerto Rico Disaster Lab' post (Landslide).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-puerto-rico-disaster-lab-map-terrain
+  path: puerto_rico_disaster_lab/map-terrain.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - puerto-rico-disaster-lab
+  alt: 'Puerto Rico Disaster Lab blog post: Map Terrain'
+  description: Blog graphic for the 'Puerto Rico Disaster Lab' post (Map Terrain).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-puerto-rico-disaster-lab-map-terrain-2
+  path: puerto_rico_disaster_lab/map-terrain.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - puerto-rico-disaster-lab
+  alt: 'Puerto Rico Disaster Lab blog post: Map Terrain'
+  description: Blog graphic for the 'Puerto Rico Disaster Lab' post (Map Terrain).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-puerto-rico-disaster-lab-municipalities
+  path: puerto_rico_disaster_lab/municipalities.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - puerto-rico-disaster-lab
+  alt: 'Puerto Rico Disaster Lab blog post: Municipalities'
+  description: Blog graphic for the 'Puerto Rico Disaster Lab' post (Municipalities).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-puerto-rico-disaster-lab-municipalities-2
+  path: puerto_rico_disaster_lab/municipalities.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - puerto-rico-disaster-lab
+  alt: 'Puerto Rico Disaster Lab blog post: Municipalities'
+  description: Blog graphic for the 'Puerto Rico Disaster Lab' post (Municipalities).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-puerto-rico-disaster-lab-scribing
+  path: puerto_rico_disaster_lab/scribing.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - puerto-rico-disaster-lab
+  alt: 'Puerto Rico Disaster Lab blog post: Scribing'
+  description: Blog graphic for the 'Puerto Rico Disaster Lab' post (Scribing).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-puerto-rico-disaster-lab-scribing-2
+  path: puerto_rico_disaster_lab/scribing.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - puerto-rico-disaster-lab
+  alt: 'Puerto Rico Disaster Lab blog post: Scribing'
+  description: Blog graphic for the 'Puerto Rico Disaster Lab' post (Scribing).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-puerto-rico-disaster-lab-snake-road
+  path: puerto_rico_disaster_lab/snake-road.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - puerto-rico-disaster-lab
+  alt: 'Puerto Rico Disaster Lab blog post: Snake Road'
+  description: Blog graphic for the 'Puerto Rico Disaster Lab' post (Snake Road).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-puerto-rico-disaster-lab-snake-road-2
+  path: puerto_rico_disaster_lab/snake-road.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - puerto-rico-disaster-lab
+  alt: 'Puerto Rico Disaster Lab blog post: Snake Road'
+  description: Blog graphic for the 'Puerto Rico Disaster Lab' post (Snake Road).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-puerto-rico-disaster-lab-woman-tanager
+  path: puerto_rico_disaster_lab/woman-tanager.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - puerto-rico-disaster-lab
+  alt: 'Puerto Rico Disaster Lab blog post: Woman Tanager'
+  description: Blog graphic for the 'Puerto Rico Disaster Lab' post (Woman Tanager).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-puerto-rico-disaster-lab-woman-tanager-2
+  path: puerto_rico_disaster_lab/woman-tanager.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - puerto-rico-disaster-lab
+  alt: 'Puerto Rico Disaster Lab blog post: Woman Tanager'
+  description: Blog graphic for the 'Puerto Rico Disaster Lab' post (Woman Tanager).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-refugee-admissions-research-refugee-admission-journey-map
+  path: refugee_admissions_research/refugee-admission-journey-map.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - refugee-admissions-research
+  alt: 'Refugee Admissions Research blog post: Refugee Admission Journey Map'
+  description: Blog graphic for the 'Refugee Admissions Research' post (Refugee Admission
+    Journey Map).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-refugee-admissions-research-refugee-admission-journey-map-2
+  path: refugee_admissions_research/refugee-admission-journey-map.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - refugee-admissions-research
+  alt: 'Refugee Admissions Research blog post: Refugee Admission Journey Map'
+  description: Blog graphic for the 'Refugee Admissions Research' post (Refugee Admission
+    Journey Map).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-refugee-admissions-research-refugee-kids-eating
+  path: refugee_admissions_research/refugee-kids-eating.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - refugee-admissions-research
+  alt: 'Refugee Admissions Research blog post: Refugee Kids Eating'
+  description: Blog graphic for the 'Refugee Admissions Research' post (Refugee Kids
+    Eating).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-refugee-admissions-research-refugee-kids-eating-2
+  path: refugee_admissions_research/refugee-kids-eating.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - refugee-admissions-research
+  alt: 'Refugee Admissions Research blog post: Refugee Kids Eating'
+  description: Blog graphic for the 'Refugee Admissions Research' post (Refugee Kids
+    Eating).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-refugee-admissions-research-refugee-kids
+  path: refugee_admissions_research/refugee-kids.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - refugee-admissions-research
+  alt: 'Refugee Admissions Research blog post: Refugee Kids'
+  description: Blog graphic for the 'Refugee Admissions Research' post (Refugee Kids).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-refugee-admissions-research-refugee-kids-2
+  path: refugee_admissions_research/refugee-kids.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - refugee-admissions-research
+  alt: 'Refugee Admissions Research blog post: Refugee Kids'
+  description: Blog graphic for the 'Refugee Admissions Research' post (Refugee Kids).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-rescue-failing-programs-rescue
+  path: rescue_failing_programs/rescue.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - rescue-failing-programs
+  alt: 'Rescue Failing Programs blog post: Rescue'
+  description: Blog graphic for the 'Rescue Failing Programs' post (Rescue).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-rescue-failing-programs-rescue-2
+  path: rescue_failing_programs/rescue.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - rescue-failing-programs
+  alt: 'Rescue Failing Programs blog post: Rescue'
+  description: Blog graphic for the 'Rescue Failing Programs' post (Rescue).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-smarter-way-to-build-smart-cities-smart-city
+  path: smarter_way_to_build_smart_cities/smart-city.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - smarter-way-to-build-smart-cities
+  alt: 'Smarter Way To Build Smart Cities blog post: Smart City'
+  description: Blog graphic for the 'Smarter Way To Build Smart Cities' post (Smart
+    City).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-smarter-way-to-build-smart-cities-smart-city-2
+  path: smarter_way_to_build_smart_cities/smart-city.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - smarter-way-to-build-smart-cities
+  alt: 'Smarter Way To Build Smart Cities blog post: Smart City'
+  description: Blog graphic for the 'Smarter Way To Build Smart Cities' post (Smart
+    City).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-software-badness-quantified-bad-code-quantified
+  path: software_badness_quantified/bad-code-quantified.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - software-badness-quantified
+  alt: 'Software Badness Quantified blog post: Bad Code Quantified'
+  description: Blog graphic for the 'Software Badness Quantified' post (Bad Code Quantified).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-software-badness-quantified-bad-code-quantified-2
+  path: software_badness_quantified/bad-code-quantified.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - software-badness-quantified
+  alt: 'Software Badness Quantified blog post: Bad Code Quantified'
+  description: Blog graphic for the 'Software Badness Quantified' post (Bad Code Quantified).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-software-badness-quantified-software-badness-quantified-graph
+  path: software_badness_quantified/software-badness-quantified-graph.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - software-badness-quantified
+  alt: 'Software Badness Quantified blog post: Software Badness Quantified Graph'
+  description: Blog graphic for the 'Software Badness Quantified' post (Software Badness
+    Quantified Graph).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-software-badness-quantified-software-badness-quantified-graph-2
+  path: software_badness_quantified/software-badness-quantified-graph.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - software-badness-quantified
+  alt: 'Software Badness Quantified blog post: Software Badness Quantified Graph'
+  description: Blog graphic for the 'Software Badness Quantified' post (Software Badness
+    Quantified Graph).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-tech-challenge-thoughts-tech-challenge-laptops-boxing
+  path: tech_challenge_thoughts/tech-challenge-laptops-boxing.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - tech-challenge-thoughts
+  alt: 'Tech Challenge Thoughts blog post: Tech Challenge Laptops Boxing'
+  description: Blog graphic for the 'Tech Challenge Thoughts' post (Tech Challenge
+    Laptops Boxing).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-tech-challenge-thoughts-tech-challenge-laptops-boxing-2
+  path: tech_challenge_thoughts/tech-challenge-laptops-boxing.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - tech-challenge-thoughts
+  alt: 'Tech Challenge Thoughts blog post: Tech Challenge Laptops Boxing'
+  description: Blog graphic for the 'Tech Challenge Thoughts' post (Tech Challenge
+    Laptops Boxing).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-tech-challenge-thoughts-vendor-procurement-pursuit-cost-benefit-decision-matrix
+  path: tech_challenge_thoughts/vendor-procurement-pursuit-cost-benefit-decision-matrix.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - tech-challenge-thoughts
+  alt: 'Tech Challenge Thoughts blog post: Vendor Procurement Pursuit Cost Benefit
+    Decision Matrix'
+  description: Blog graphic for the 'Tech Challenge Thoughts' post (Vendor Procurement
+    Pursuit Cost Benefit Decision Matrix).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: blog-tech-challenge-thoughts-vendor-procurement-pursuit-cost-benefit-decision-matrix-2
+  path: tech_challenge_thoughts/vendor-procurement-pursuit-cost-benefit-decision-matrix.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes: []
+  tags: []
+  used_in:
+  - tech-challenge-thoughts
+  alt: 'Tech Challenge Thoughts blog post: Vendor Procurement Pursuit Cost Benefit
+    Decision Matrix'
+  description: Blog graphic for the 'Tech Challenge Thoughts' post (Vendor Procurement
+    Pursuit Cost Benefit Decision Matrix).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false

--- a/img/brand/assets-manifest.yml
+++ b/img/brand/assets-manifest.yml
@@ -91,9 +91,9 @@
   themes:
   - brand
   tags: []
-  alt: 'Brand-guide page-header illustration: Illustration Illustration Types'
-  description: Page-header (hero) illustration for the brand-guide Illustration Illustration
-    Types page on skylight.digital.
+  alt: 'Brand-guide page-header illustration: Illustration Types'
+  description: Page-header (hero) illustration for the brand-guide Illustration Types
+    page on skylight.digital.
   permissions: skylight-owned
   classification: public
   archived: false

--- a/img/people/assets-manifest.yml
+++ b/img/people/assets-manifest.yml
@@ -1,0 +1,6845 @@
+# Federation asset manifest -- skylight.digital img/people (Phase C.2).
+# Path-derived enrichment; all assets are Skylight's own on the public site
+# -> permissions: skylight-owned, classification: public. ids are path-based.
+# NOTE: judgment fields the team should refine -- which people are current vs.
+# former (archive those), client/mission tags per project, and richer alt text.
+- id: person-aaron-owens
+  path: aaron-owens.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - aaron-owens
+  alt: Headshot of Aaron Owens
+  description: Team headshot of Aaron Owens, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-aaron-owens-2
+  path: aaron-owens.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - aaron-owens
+  alt: Headshot of Aaron Owens
+  description: Team headshot of Aaron Owens, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-abby-raskin
+  path: abby-raskin.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - abby-raskin
+  alt: Headshot of Abby Raskin
+  description: Team headshot of Abby Raskin, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-abraham-lincoln
+  path: abraham-lincoln.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - abraham-lincoln
+  alt: Headshot of Abraham Lincoln
+  description: Team headshot of Abraham Lincoln, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-adam-weber
+  path: adam-weber.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - adam-weber
+  alt: Headshot of Adam Weber
+  description: Team headshot of Adam Weber, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-aera-hoffman
+  path: aera-hoffman.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - aera-hoffman
+  alt: Headshot of Aera Hoffman
+  description: Team headshot of Aera Hoffman, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-aimee-knight
+  path: aimee-knight.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - aimee-knight
+  alt: Headshot of Aimee Knight
+  description: Team headshot of Aimee Knight, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-aimee-knight-2
+  path: aimee-knight.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - aimee-knight
+  alt: Headshot of Aimee Knight
+  description: Team headshot of Aimee Knight, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-alex-bornkessel
+  path: alex-bornkessel.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - alex-bornkessel
+  alt: Headshot of Alex Bornkessel
+  description: Team headshot of Alex Bornkessel, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-alex-bornkessel-2
+  path: alex-bornkessel.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - alex-bornkessel
+  alt: Headshot of Alex Bornkessel
+  description: Team headshot of Alex Bornkessel, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-alex-hayward
+  path: alex-hayward.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - alex-hayward
+  alt: Headshot of Alex Hayward
+  description: Team headshot of Alex Hayward, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-alex-hayward-2
+  path: alex-hayward.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - alex-hayward
+  alt: Headshot of Alex Hayward
+  description: Team headshot of Alex Hayward, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-alex-hayward-3
+  path: alex-hayward.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - alex-hayward
+  alt: Headshot of Alex Hayward
+  description: Team headshot of Alex Hayward, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-alexander-curtis
+  path: alexander-curtis.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - alexander-curtis
+  alt: Headshot of Alexander Curtis
+  description: Team headshot of Alexander Curtis, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-alis-akers
+  path: alis-akers.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - alis-akers
+  alt: Headshot of Alis Akers
+  description: Team headshot of Alis Akers, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-alis-akers-2
+  path: alis-akers.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - alis-akers
+  alt: Headshot of Alis Akers
+  description: Team headshot of Alis Akers, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-allyn-charlefour
+  path: allyn-charlefour.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - allyn-charlefour
+  alt: Headshot of Allyn Charlefour
+  description: Team headshot of Allyn Charlefour, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-allyn-charlefour-2
+  path: allyn-charlefour.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - allyn-charlefour
+  alt: Headshot of Allyn Charlefour
+  description: Team headshot of Allyn Charlefour, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-amelia-wellers
+  path: amelia-wellers.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - amelia-wellers
+  alt: Headshot of Amelia Wellers
+  description: Team headshot of Amelia Wellers, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-amrita-bhatti
+  path: amrita-bhatti.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - amrita-bhatti
+  alt: Headshot of Amrita Bhatti
+  description: Team headshot of Amrita Bhatti, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-amrita-bhatti-2
+  path: amrita-bhatti.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - amrita-bhatti
+  alt: Headshot of Amrita Bhatti
+  description: Team headshot of Amrita Bhatti, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-amy-kintner
+  path: amy-kintner.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - amy-kintner
+  alt: Headshot of Amy Kintner
+  description: Team headshot of Amy Kintner, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-amy-kintner-2
+  path: amy-kintner.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - amy-kintner
+  alt: Headshot of Amy Kintner
+  description: Team headshot of Amy Kintner, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-amy-kintner-3
+  path: amy-kintner.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - amy-kintner
+  alt: Headshot of Amy Kintner
+  description: Team headshot of Amy Kintner, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-andrew-kasper
+  path: andrew-kasper.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - andrew-kasper
+  alt: Headshot of Andrew Kasper
+  description: Team headshot of Andrew Kasper, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-andrew-kasper-2
+  path: andrew-kasper.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - andrew-kasper
+  alt: Headshot of Andrew Kasper
+  description: Team headshot of Andrew Kasper, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-andrew-kramer
+  path: andrew-kramer.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - andrew-kramer
+  alt: Headshot of Andrew Kramer
+  description: Team headshot of Andrew Kramer, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-andrew-kramer-2
+  path: andrew-kramer.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - andrew-kramer
+  alt: Headshot of Andrew Kramer
+  description: Team headshot of Andrew Kramer, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-andrew-lloyd
+  path: andrew-lloyd.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - andrew-lloyd
+  alt: Headshot of Andrew Lloyd
+  description: Team headshot of Andrew Lloyd, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-andrew-schreiber
+  path: andrew-schreiber.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - andrew-schreiber
+  alt: Headshot of Andrew Schreiber
+  description: Team headshot of Andrew Schreiber, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-andrew-schreiber-2
+  path: andrew-schreiber.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - andrew-schreiber
+  alt: Headshot of Andrew Schreiber
+  description: Team headshot of Andrew Schreiber, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-andrew-wagner
+  path: andrew-wagner.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - andrew-wagner
+  alt: Headshot of Andrew Wagner
+  description: Team headshot of Andrew Wagner, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-angela-the
+  path: angela-the.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - angela-the
+  alt: Headshot of Angela The
+  description: Team headshot of Angela The, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-angela-the-2
+  path: angela-the.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - angela-the
+  alt: Headshot of Angela The
+  description: Team headshot of Angela The, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-angela-the-3
+  path: angela-the.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - angela-the
+  alt: Headshot of Angela The
+  description: Team headshot of Angela The, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-anke-stohlmann
+  path: anke-stohlmann.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - anke-stohlmann
+  alt: Headshot of Anke Stohlmann
+  description: Team headshot of Anke Stohlmann, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-anke-stohlmann-2
+  path: anke-stohlmann.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - anke-stohlmann
+  alt: Headshot of Anke Stohlmann
+  description: Team headshot of Anke Stohlmann, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-ann-millspaugh
+  path: ann-millspaugh.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - ann-millspaugh
+  alt: Headshot of Ann Millspaugh
+  description: Team headshot of Ann Millspaugh, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-ann-millspaugh-2
+  path: ann-millspaugh.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - ann-millspaugh
+  alt: Headshot of Ann Millspaugh
+  description: Team headshot of Ann Millspaugh, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-ann-millspaugh-3
+  path: ann-millspaugh.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - ann-millspaugh
+  alt: Headshot of Ann Millspaugh
+  description: Team headshot of Ann Millspaugh, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-ari-perez
+  path: ari-perez.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - ari-perez
+  alt: Headshot of Ari Perez
+  description: Team headshot of Ari Perez, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-arindam-kulshi
+  path: arindam-kulshi.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - arindam-kulshi
+  alt: Headshot of Arindam Kulshi
+  description: Team headshot of Arindam Kulshi, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-arindam-kulshi-2
+  path: arindam-kulshi.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - arindam-kulshi
+  alt: Headshot of Arindam Kulshi
+  description: Team headshot of Arindam Kulshi, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-arindam-kulshi-3
+  path: arindam-kulshi.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - arindam-kulshi
+  alt: Headshot of Arindam Kulshi
+  description: Team headshot of Arindam Kulshi, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-ashley-treni
+  path: ashley-treni.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - ashley-treni
+  alt: Headshot of Ashley Treni
+  description: Team headshot of Ashley Treni, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-ashton-tu
+  path: ashton-tu.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - ashton-tu
+  alt: Headshot of Ashton Tu
+  description: Team headshot of Ashton Tu, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-ashton-tu-2
+  path: ashton-tu.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - ashton-tu
+  alt: Headshot of Ashton Tu
+  description: Team headshot of Ashton Tu, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-ashton-tu-3
+  path: ashton-tu.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - ashton-tu
+  alt: Headshot of Ashton Tu
+  description: Team headshot of Ashton Tu, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-audrey-ross
+  path: audrey-ross.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - audrey-ross
+  alt: Headshot of Audrey Ross
+  description: Team headshot of Audrey Ross, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-audrey-ross-2
+  path: audrey-ross.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - audrey-ross
+  alt: Headshot of Audrey Ross
+  description: Team headshot of Audrey Ross, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-austin-brown
+  path: austin-brown.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - austin-brown
+  alt: Headshot of Austin Brown
+  description: Team headshot of Austin Brown, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-austin-brown-2
+  path: austin-brown.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - austin-brown
+  alt: Headshot of Austin Brown
+  description: Team headshot of Austin Brown, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-austin-brown-3
+  path: austin-brown.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - austin-brown
+  alt: Headshot of Austin Brown
+  description: Team headshot of Austin Brown, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-austin-hall
+  path: austin-hall.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - austin-hall
+  alt: Headshot of Austin Hall
+  description: Team headshot of Austin Hall, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-austin-hall-2
+  path: austin-hall.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - austin-hall
+  alt: Headshot of Austin Hall
+  description: Team headshot of Austin Hall, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-becca-bartola
+  path: becca-bartola.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - becca-bartola
+  alt: Headshot of Becca Bartola
+  description: Team headshot of Becca Bartola, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-becca-bartola-2
+  path: becca-bartola.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - becca-bartola
+  alt: Headshot of Becca Bartola
+  description: Team headshot of Becca Bartola, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-becca-bartola-3
+  path: becca-bartola.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - becca-bartola
+  alt: Headshot of Becca Bartola
+  description: Team headshot of Becca Bartola, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-becca-woodberry
+  path: becca-woodberry.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - becca-woodberry
+  alt: Headshot of Becca Woodberry
+  description: Team headshot of Becca Woodberry, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-becca-woodberry-2
+  path: becca-woodberry.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - becca-woodberry
+  alt: Headshot of Becca Woodberry
+  description: Team headshot of Becca Woodberry, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-bob-zhao
+  path: bob-zhao.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - bob-zhao
+  alt: Headshot of Bob Zhao
+  description: Team headshot of Bob Zhao, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-bob-zhao-2
+  path: bob-zhao.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - bob-zhao
+  alt: Headshot of Bob Zhao
+  description: Team headshot of Bob Zhao, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-bob-zhao-3
+  path: bob-zhao.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - bob-zhao
+  alt: Headshot of Bob Zhao
+  description: Team headshot of Bob Zhao, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-boban-ljuljdjurovic
+  path: boban-ljuljdjurovic.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - boban-ljuljdjurovic
+  alt: Headshot of Boban Ljuljdjurovic
+  description: Team headshot of Boban Ljuljdjurovic, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-boban-ljuljdjurovic-2
+  path: boban-ljuljdjurovic.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - boban-ljuljdjurovic
+  alt: Headshot of Boban Ljuljdjurovic
+  description: Team headshot of Boban Ljuljdjurovic, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-boban-ljuljdjurovic-3
+  path: boban-ljuljdjurovic.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - boban-ljuljdjurovic
+  alt: Headshot of Boban Ljuljdjurovic
+  description: Team headshot of Boban Ljuljdjurovic, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-bobby-wells
+  path: bobby-wells.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - bobby-wells
+  alt: Headshot of Bobby Wells
+  description: Team headshot of Bobby Wells, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-brady-fausett
+  path: brady-fausett.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - brady-fausett
+  alt: Headshot of Brady Fausett
+  description: Team headshot of Brady Fausett, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-brady-fausett-2
+  path: brady-fausett.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - brady-fausett
+  alt: Headshot of Brady Fausett
+  description: Team headshot of Brady Fausett, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-brandon-chanco
+  path: brandon-chanco.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - brandon-chanco
+  alt: Headshot of Brandon Chanco
+  description: Team headshot of Brandon Chanco, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-brandon-chanco-2
+  path: brandon-chanco.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - brandon-chanco
+  alt: Headshot of Brandon Chanco
+  description: Team headshot of Brandon Chanco, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-brandon-chanco-3
+  path: brandon-chanco.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - brandon-chanco
+  alt: Headshot of Brandon Chanco
+  description: Team headshot of Brandon Chanco, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-brandon-kirby
+  path: brandon-kirby.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - brandon-kirby
+  alt: Headshot of Brandon Kirby
+  description: Team headshot of Brandon Kirby, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-brandon-mader
+  path: brandon-mader.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - brandon-mader
+  alt: Headshot of Brandon Mader
+  description: Team headshot of Brandon Mader, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-brandon-mader-2
+  path: brandon-mader.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - brandon-mader
+  alt: Headshot of Brandon Mader
+  description: Team headshot of Brandon Mader, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-brandon-mader-3
+  path: brandon-mader.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - brandon-mader
+  alt: Headshot of Brandon Mader
+  description: Team headshot of Brandon Mader, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-brandon-sanchez
+  path: brandon-sanchez.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - brandon-sanchez
+  alt: Headshot of Brandon Sanchez
+  description: Team headshot of Brandon Sanchez, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-bruce-jacobson
+  path: bruce-jacobson.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - bruce-jacobson
+  alt: Headshot of Bruce Jacobson
+  description: Team headshot of Bruce Jacobson, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-bruce-jacobson-2
+  path: bruce-jacobson.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - bruce-jacobson
+  alt: Headshot of Bruce Jacobson
+  description: Team headshot of Bruce Jacobson, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-bruce-jacobson-3
+  path: bruce-jacobson.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - bruce-jacobson
+  alt: Headshot of Bruce Jacobson
+  description: Team headshot of Bruce Jacobson, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-bryan-britten
+  path: bryan-britten.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - bryan-britten
+  alt: Headshot of Bryan Britten
+  description: Team headshot of Bryan Britten, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-cailyn-hansen
+  path: cailyn-hansen.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - cailyn-hansen
+  alt: Headshot of Cailyn Hansen
+  description: Team headshot of Cailyn Hansen, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-caitlin-rinn
+  path: caitlin-rinn.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - caitlin-rinn
+  alt: Headshot of Caitlin Rinn
+  description: Team headshot of Caitlin Rinn, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-caitlin-rinn-2
+  path: caitlin-rinn.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - caitlin-rinn
+  alt: Headshot of Caitlin Rinn
+  description: Team headshot of Caitlin Rinn, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-camille-villa
+  path: camille-villa.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - camille-villa
+  alt: Headshot of Camille Villa
+  description: Team headshot of Camille Villa, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-camille-villa-2
+  path: camille-villa.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - camille-villa
+  alt: Headshot of Camille Villa
+  description: Team headshot of Camille Villa, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-cara-pickett
+  path: cara-pickett.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - cara-pickett
+  alt: Headshot of Cara Pickett
+  description: Team headshot of Cara Pickett, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-cara-pickett-2
+  path: cara-pickett.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - cara-pickett
+  alt: Headshot of Cara Pickett
+  description: Team headshot of Cara Pickett, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-carla-chapa
+  path: carla-chapa.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - carla-chapa
+  alt: Headshot of Carla Chapa
+  description: Team headshot of Carla Chapa, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-carla-chapa-2
+  path: carla-chapa.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - carla-chapa
+  alt: Headshot of Carla Chapa
+  description: Team headshot of Carla Chapa, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-charlye-tran
+  path: charlye-tran.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - charlye-tran
+  alt: Headshot of Charlye Tran
+  description: Team headshot of Charlye Tran, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-cheryl-hammond
+  path: cheryl-hammond.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - cheryl-hammond
+  alt: Headshot of Cheryl Hammond
+  description: Team headshot of Cheryl Hammond, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-cheyenne-meredith
+  path: cheyenne-meredith.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - cheyenne-meredith
+  alt: Headshot of Cheyenne Meredith
+  description: Team headshot of Cheyenne Meredith, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-cheyenne-meredith-2
+  path: cheyenne-meredith.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - cheyenne-meredith
+  alt: Headshot of Cheyenne Meredith
+  description: Team headshot of Cheyenne Meredith, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-chinelo-ikejimba
+  path: chinelo-ikejimba.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - chinelo-ikejimba
+  alt: Headshot of Chinelo Ikejimba
+  description: Team headshot of Chinelo Ikejimba, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-chinelo-ikejimba-2
+  path: chinelo-ikejimba.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - chinelo-ikejimba
+  alt: Headshot of Chinelo Ikejimba
+  description: Team headshot of Chinelo Ikejimba, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-chris-cairns
+  path: chris-cairns.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - chris-cairns
+  alt: Headshot of Chris Cairns
+  description: Team headshot of Chris Cairns, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-chris-cairns-2
+  path: chris-cairns.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - chris-cairns
+  alt: Headshot of Chris Cairns
+  description: Team headshot of Chris Cairns, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-chris-cairns-3
+  path: chris-cairns.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - chris-cairns
+  alt: Headshot of Chris Cairns
+  description: Team headshot of Chris Cairns, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-chris-connolly
+  path: chris-connolly.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - chris-connolly
+  alt: Headshot of Chris Connolly
+  description: Team headshot of Chris Connolly, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-chris-connolly-2
+  path: chris-connolly.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - chris-connolly
+  alt: Headshot of Chris Connolly
+  description: Team headshot of Chris Connolly, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-chris-given
+  path: chris-given.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - chris-given
+  alt: Headshot of Chris Given
+  description: Team headshot of Chris Given, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-chris-smith
+  path: chris-smith.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - chris-smith
+  alt: Headshot of Chris Smith
+  description: Team headshot of Chris Smith, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-christopher-whitaker
+  path: christopher-whitaker.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - christopher-whitaker
+  alt: Headshot of Christopher Whitaker
+  description: Team headshot of Christopher Whitaker, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-christopher-whitaker-2
+  path: christopher-whitaker.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - christopher-whitaker
+  alt: Headshot of Christopher Whitaker
+  description: Team headshot of Christopher Whitaker, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-christopher-whitaker-3
+  path: christopher-whitaker.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - christopher-whitaker
+  alt: Headshot of Christopher Whitaker
+  description: Team headshot of Christopher Whitaker, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-chun-yen
+  path: chun-yen.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - chun-yen
+  alt: Headshot of Chun Yen
+  description: Team headshot of Chun Yen, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-colin-craig
+  path: colin-craig.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - colin-craig
+  alt: Headshot of Colin Craig
+  description: Team headshot of Colin Craig, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-corinne-barker
+  path: corinne-barker.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - corinne-barker
+  alt: Headshot of Corinne Barker
+  description: Team headshot of Corinne Barker, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-corinne-barker-2
+  path: corinne-barker.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - corinne-barker
+  alt: Headshot of Corinne Barker
+  description: Team headshot of Corinne Barker, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-dan-levenson
+  path: dan-levenson.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - dan-levenson
+  alt: Headshot of Dan Levenson
+  description: Team headshot of Dan Levenson, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-dan-paseltiner
+  path: dan-paseltiner.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - dan-paseltiner
+  alt: Headshot of Dan Paseltiner
+  description: Team headshot of Dan Paseltiner, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-dan-paseltiner-2
+  path: dan-paseltiner.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - dan-paseltiner
+  alt: Headshot of Dan Paseltiner
+  description: Team headshot of Dan Paseltiner, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-dan-paseltiner-3
+  path: dan-paseltiner.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - dan-paseltiner
+  alt: Headshot of Dan Paseltiner
+  description: Team headshot of Dan Paseltiner, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-dan-sass
+  path: dan-sass.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - dan-sass
+  alt: Headshot of Dan Sass
+  description: Team headshot of Dan Sass, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-dan-sass-2
+  path: dan-sass.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - dan-sass
+  alt: Headshot of Dan Sass
+  description: Team headshot of Dan Sass, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-dan-sass-3
+  path: dan-sass.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - dan-sass
+  alt: Headshot of Dan Sass
+  description: Team headshot of Dan Sass, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-dana-nelson
+  path: dana-nelson.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - dana-nelson
+  alt: Headshot of Dana Nelson
+  description: Team headshot of Dana Nelson, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-dana-nelson-2
+  path: dana-nelson.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - dana-nelson
+  alt: Headshot of Dana Nelson
+  description: Team headshot of Dana Nelson, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-dana-nelson-3
+  path: dana-nelson.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - dana-nelson
+  alt: Headshot of Dana Nelson
+  description: Team headshot of Dana Nelson, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-david-mcclatchey
+  path: david-mcclatchey.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - david-mcclatchey
+  alt: Headshot of David Mcclatchey
+  description: Team headshot of David Mcclatchey, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-david-mcclatchey-2
+  path: david-mcclatchey.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - david-mcclatchey
+  alt: Headshot of David Mcclatchey
+  description: Team headshot of David Mcclatchey, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-david-mcclatchey-3
+  path: david-mcclatchey.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - david-mcclatchey
+  alt: Headshot of David Mcclatchey
+  description: Team headshot of David Mcclatchey, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-derek-tam
+  path: derek-tam.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - derek-tam
+  alt: Headshot of Derek Tam
+  description: Team headshot of Derek Tam, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-eileen-ruberto
+  path: eileen-ruberto.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - eileen-ruberto
+  alt: Headshot of Eileen Ruberto
+  description: Team headshot of Eileen Ruberto, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-eileen-ruberto-2
+  path: eileen-ruberto.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - eileen-ruberto
+  alt: Headshot of Eileen Ruberto
+  description: Team headshot of Eileen Ruberto, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-eileen-ruberto-3
+  path: eileen-ruberto.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - eileen-ruberto
+  alt: Headshot of Eileen Ruberto
+  description: Team headshot of Eileen Ruberto, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-eleanor-hyman
+  path: eleanor-hyman.png
+  repo: skylight.digital
+  date: '2026-05-15'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - eleanor-hyman
+  alt: Headshot of Eleanor Hyman
+  description: Team headshot of Eleanor Hyman, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-eleanor-hyman-2
+  path: eleanor-hyman.svg
+  repo: skylight.digital
+  date: '2026-05-15'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - eleanor-hyman
+  alt: Headshot of Eleanor Hyman
+  description: Team headshot of Eleanor Hyman, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-eleanor-roosevelt
+  path: eleanor-roosevelt.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - eleanor-roosevelt
+  alt: Headshot of Eleanor Roosevelt
+  description: Team headshot of Eleanor Roosevelt, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-elisa-lee
+  path: elisa-lee.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - elisa-lee
+  alt: Headshot of Elisa Lee
+  description: Team headshot of Elisa Lee, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-elisa-lee-2
+  path: elisa-lee.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - elisa-lee
+  alt: Headshot of Elisa Lee
+  description: Team headshot of Elisa Lee, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-elisa-lee-3
+  path: elisa-lee.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - elisa-lee
+  alt: Headshot of Elisa Lee
+  description: Team headshot of Elisa Lee, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-elyse-brumfield
+  path: elyse-brumfield.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - elyse-brumfield
+  alt: Headshot of Elyse Brumfield
+  description: Team headshot of Elyse Brumfield, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-emily-alter
+  path: emily-alter.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - emily-alter
+  alt: Headshot of Emily Alter
+  description: Team headshot of Emily Alter, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-emma-stephenson
+  path: emma-stephenson.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - emma-stephenson
+  alt: Headshot of Emma Stephenson
+  description: Team headshot of Emma Stephenson, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-emma-stephenson-2
+  path: emma-stephenson.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - emma-stephenson
+  alt: Headshot of Emma Stephenson
+  description: Team headshot of Emma Stephenson, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-emma-stephenson-3
+  path: emma-stephenson.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - emma-stephenson
+  alt: Headshot of Emma Stephenson
+  description: Team headshot of Emma Stephenson, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-emmanuel-nwakire
+  path: emmanuel-nwakire.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - emmanuel-nwakire
+  alt: Headshot of Emmanuel Nwakire
+  description: Team headshot of Emmanuel Nwakire, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-emmanuel-nwakire-2
+  path: emmanuel-nwakire.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - emmanuel-nwakire
+  alt: Headshot of Emmanuel Nwakire
+  description: Team headshot of Emmanuel Nwakire, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-emmanuel-nwakire-3
+  path: emmanuel-nwakire.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - emmanuel-nwakire
+  alt: Headshot of Emmanuel Nwakire
+  description: Team headshot of Emmanuel Nwakire, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-eric-buckley
+  path: eric-buckley.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - eric-buckley
+  alt: Headshot of Eric Buckley
+  description: Team headshot of Eric Buckley, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-eric-buckley-2
+  path: eric-buckley.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - eric-buckley
+  alt: Headshot of Eric Buckley
+  description: Team headshot of Eric Buckley, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-eric-buckley-3
+  path: eric-buckley.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - eric-buckley
+  alt: Headshot of Eric Buckley
+  description: Team headshot of Eric Buckley, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-eric-richards
+  path: eric-richards.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - eric-richards
+  alt: Headshot of Eric Richards
+  description: Team headshot of Eric Richards, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-evan-bowers
+  path: evan-bowers.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - evan-bowers
+  alt: Headshot of Evan Bowers
+  description: Team headshot of Evan Bowers, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-gabriel-ramirez
+  path: gabriel-ramirez.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - gabriel-ramirez
+  alt: Headshot of Gabriel Ramirez
+  description: Team headshot of Gabriel Ramirez, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-geoff-mulligan
+  path: geoff-mulligan.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - geoff-mulligan
+  alt: Headshot of Geoff Mulligan
+  description: Team headshot of Geoff Mulligan, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-geoff-mulligan-2
+  path: geoff-mulligan.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - geoff-mulligan
+  alt: Headshot of Geoff Mulligan
+  description: Team headshot of Geoff Mulligan, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-geoff-mulligan-3
+  path: geoff-mulligan.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - geoff-mulligan
+  alt: Headshot of Geoff Mulligan
+  description: Team headshot of Geoff Mulligan, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-gianna-buda
+  path: gianna-buda.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - gianna-buda
+  alt: Headshot of Gianna Buda
+  description: Team headshot of Gianna Buda, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-gianna-buda-2
+  path: gianna-buda.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - gianna-buda
+  alt: Headshot of Gianna Buda
+  description: Team headshot of Gianna Buda, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-gianna-buda-3
+  path: gianna-buda.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - gianna-buda
+  alt: Headshot of Gianna Buda
+  description: Team headshot of Gianna Buda, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-gordon-farrell
+  path: gordon-farrell.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - gordon-farrell
+  alt: Headshot of Gordon Farrell
+  description: Team headshot of Gordon Farrell, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-gordon-farrell-2
+  path: gordon-farrell.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - gordon-farrell
+  alt: Headshot of Gordon Farrell
+  description: Team headshot of Gordon Farrell, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-gordon-farrell-3
+  path: gordon-farrell.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - gordon-farrell
+  alt: Headshot of Gordon Farrell
+  description: Team headshot of Gordon Farrell, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-grace-zhou
+  path: grace-zhou.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - grace-zhou
+  alt: Headshot of Grace Zhou
+  description: Team headshot of Grace Zhou, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-grace-zhou-2
+  path: grace-zhou.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - grace-zhou
+  alt: Headshot of Grace Zhou
+  description: Team headshot of Grace Zhou, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-graham-smith
+  path: graham-smith.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - graham-smith
+  alt: Headshot of Graham Smith
+  description: Team headshot of Graham Smith, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-holly-dewolf
+  path: holly-dewolf.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - holly-dewolf
+  alt: Headshot of Holly Dewolf
+  description: Team headshot of Holly Dewolf, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-holly-dewolf-2
+  path: holly-dewolf.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - holly-dewolf
+  alt: Headshot of Holly Dewolf
+  description: Team headshot of Holly Dewolf, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-holly-dewolf-3
+  path: holly-dewolf.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - holly-dewolf
+  alt: Headshot of Holly Dewolf
+  description: Team headshot of Holly Dewolf, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-ian-hancock
+  path: ian-hancock.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - ian-hancock
+  alt: Headshot of Ian Hancock
+  description: Team headshot of Ian Hancock, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jackie-ostrowski
+  path: jackie-ostrowski.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jackie-ostrowski
+  alt: Headshot of Jackie Ostrowski
+  description: Team headshot of Jackie Ostrowski, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jackie-ostrowski-2
+  path: jackie-ostrowski.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jackie-ostrowski
+  alt: Headshot of Jackie Ostrowski
+  description: Team headshot of Jackie Ostrowski, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jake-wheeler
+  path: jake-wheeler.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jake-wheeler
+  alt: Headshot of Jake Wheeler
+  description: Team headshot of Jake Wheeler, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jake-wheeler-2
+  path: jake-wheeler.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jake-wheeler
+  alt: Headshot of Jake Wheeler
+  description: Team headshot of Jake Wheeler, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jamie-song
+  path: jamie-song.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jamie-song
+  alt: Headshot of Jamie Song
+  description: Team headshot of Jamie Song, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-janki-kaneria
+  path: janki-kaneria.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - janki-kaneria
+  alt: Headshot of Janki Kaneria
+  description: Team headshot of Janki Kaneria, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-janki-kaneria-2
+  path: janki-kaneria.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - janki-kaneria
+  alt: Headshot of Janki Kaneria
+  description: Team headshot of Janki Kaneria, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jay-danielian
+  path: jay-danielian.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jay-danielian
+  alt: Headshot of Jay Danielian
+  description: Team headshot of Jay Danielian, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jayna-wallace
+  path: jayna-wallace.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jayna-wallace
+  alt: Headshot of Jayna Wallace
+  description: Team headshot of Jayna Wallace, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jeff-auser
+  path: jeff-auser.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jeff-auser
+  alt: Headshot of Jeff Auser
+  description: Team headshot of Jeff Auser, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jeff-auser-2
+  path: jeff-auser.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jeff-auser
+  alt: Headshot of Jeff Auser
+  description: Team headshot of Jeff Auser, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jeff-bostick
+  path: jeff-bostick.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jeff-bostick
+  alt: Headshot of Jeff Bostick
+  description: Team headshot of Jeff Bostick, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jeff-bostick-2
+  path: jeff-bostick.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jeff-bostick
+  alt: Headshot of Jeff Bostick
+  description: Team headshot of Jeff Bostick, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jeff-johnson
+  path: jeff-johnson.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jeff-johnson
+  alt: Headshot of Jeff Johnson
+  description: Team headshot of Jeff Johnson, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jeff-johnson-2
+  path: jeff-johnson.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jeff-johnson
+  alt: Headshot of Jeff Johnson
+  description: Team headshot of Jeff Johnson, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jennifer-herzberg
+  path: jennifer-herzberg.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jennifer-herzberg
+  alt: Headshot of Jennifer Herzberg
+  description: Team headshot of Jennifer Herzberg, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jennifer-herzberg-2
+  path: jennifer-herzberg.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jennifer-herzberg
+  alt: Headshot of Jennifer Herzberg
+  description: Team headshot of Jennifer Herzberg, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jennifer-herzberg-3
+  path: jennifer-herzberg.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jennifer-herzberg
+  alt: Headshot of Jennifer Herzberg
+  description: Team headshot of Jennifer Herzberg, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jennifer-wilhelm
+  path: jennifer-wilhelm.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jennifer-wilhelm
+  alt: Headshot of Jennifer Wilhelm
+  description: Team headshot of Jennifer Wilhelm, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jennifer-wilhelm-2
+  path: jennifer-wilhelm.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jennifer-wilhelm
+  alt: Headshot of Jennifer Wilhelm
+  description: Team headshot of Jennifer Wilhelm, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jenny-payne
+  path: jenny-payne.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jenny-payne
+  alt: Headshot of Jenny Payne
+  description: Team headshot of Jenny Payne, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jenny-payne-2
+  path: jenny-payne.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jenny-payne
+  alt: Headshot of Jenny Payne
+  description: Team headshot of Jenny Payne, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jesse-skeets
+  path: jesse-skeets.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jesse-skeets
+  alt: Headshot of Jesse Skeets
+  description: Team headshot of Jesse Skeets, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jill-fromewick
+  path: jill-fromewick.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jill-fromewick
+  alt: Headshot of Jill Fromewick
+  description: Team headshot of Jill Fromewick, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jill-fromewick-2
+  path: jill-fromewick.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jill-fromewick
+  alt: Headshot of Jill Fromewick
+  description: Team headshot of Jill Fromewick, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jina-ryu
+  path: jina-ryu.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jina-ryu
+  alt: Headshot of Jina Ryu
+  description: Team headshot of Jina Ryu, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-joe-reynolds
+  path: joe-reynolds.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - joe-reynolds
+  alt: Headshot of Joe Reynolds
+  description: Team headshot of Joe Reynolds, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-johanna-del-pino
+  path: johanna-del-pino.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - johanna-del-pino
+  alt: Headshot of Johanna Del Pino
+  description: Team headshot of Johanna Del Pino, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-johanna-del-pino-2
+  path: johanna-del-pino.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - johanna-del-pino
+  alt: Headshot of Johanna Del Pino
+  description: Team headshot of Johanna Del Pino, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-johanna-delpino
+  path: johanna-delpino.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - johanna-delpino
+  alt: Headshot of Johanna Delpino
+  description: Team headshot of Johanna Delpino, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-john-teeter
+  path: john-teeter.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - john-teeter
+  alt: Headshot of John Teeter
+  description: Team headshot of John Teeter, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jonathan-chang
+  path: jonathan-chang.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jonathan-chang
+  alt: Headshot of Jonathan Chang
+  description: Team headshot of Jonathan Chang, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jordan-guinn
+  path: jordan-guinn.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jordan-guinn
+  alt: Headshot of Jordan Guinn
+  description: Team headshot of Jordan Guinn, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-jordan-guinn-2
+  path: jordan-guinn.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - jordan-guinn
+  alt: Headshot of Jordan Guinn
+  description: Team headshot of Jordan Guinn, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-josh-dorothy
+  path: josh-dorothy.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - josh-dorothy
+  alt: Headshot of Josh Dorothy
+  description: Team headshot of Josh Dorothy, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-josh-dorothy-2
+  path: josh-dorothy.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - josh-dorothy
+  alt: Headshot of Josh Dorothy
+  description: Team headshot of Josh Dorothy, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-josh-dorothy-3
+  path: josh-dorothy.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - josh-dorothy
+  alt: Headshot of Josh Dorothy
+  description: Team headshot of Josh Dorothy, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-josh-nygaard
+  path: josh-nygaard.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - josh-nygaard
+  alt: Headshot of Josh Nygaard
+  description: Team headshot of Josh Nygaard, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-josh-nygaard-2
+  path: josh-nygaard.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - josh-nygaard
+  alt: Headshot of Josh Nygaard
+  description: Team headshot of Josh Nygaard, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-julia-hogan
+  path: julia-hogan.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - julia-hogan
+  alt: Headshot of Julia Hogan
+  description: Team headshot of Julia Hogan, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kallen-michaels
+  path: kallen-michaels.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kallen-michaels
+  alt: Headshot of Kallen Michaels
+  description: Team headshot of Kallen Michaels, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kari-hodges
+  path: kari-hodges.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kari-hodges
+  alt: Headshot of Kari Hodges
+  description: Team headshot of Kari Hodges, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-karina-wernecke
+  path: karina-wernecke.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - karina-wernecke
+  alt: Headshot of Karina Wernecke
+  description: Team headshot of Karina Wernecke, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-karina-wernecke-2
+  path: karina-wernecke.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - karina-wernecke
+  alt: Headshot of Karina Wernecke
+  description: Team headshot of Karina Wernecke, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-karina-wernecke-3
+  path: karina-wernecke.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - karina-wernecke
+  alt: Headshot of Karina Wernecke
+  description: Team headshot of Karina Wernecke, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-karthik-patil
+  path: karthik-patil.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - karthik-patil
+  alt: Headshot of Karthik Patil
+  description: Team headshot of Karthik Patil, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kate-green
+  path: kate-green.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kate-green
+  alt: Headshot of Kate Green
+  description: Team headshot of Kate Green, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kate-green-2
+  path: kate-green.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kate-green
+  alt: Headshot of Kate Green
+  description: Team headshot of Kate Green, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kate-saul
+  path: kate-saul.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kate-saul
+  alt: Headshot of Kate Saul
+  description: Team headshot of Kate Saul, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kate-saul-2
+  path: kate-saul.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kate-saul
+  alt: Headshot of Kate Saul
+  description: Team headshot of Kate Saul, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kathryn-mullins
+  path: kathryn-mullins.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kathryn-mullins
+  alt: Headshot of Kathryn Mullins
+  description: Team headshot of Kathryn Mullins, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-katie-campbell-downie
+  path: katie-campbell-downie.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - katie-campbell-downie
+  alt: Headshot of Katie Campbell Downie
+  description: Team headshot of Katie Campbell Downie, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-katie-campbell-downie-2
+  path: katie-campbell-downie.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - katie-campbell-downie
+  alt: Headshot of Katie Campbell Downie
+  description: Team headshot of Katie Campbell Downie, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-katie-campbell-downie-3
+  path: katie-campbell-downie.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - katie-campbell-downie
+  alt: Headshot of Katie Campbell Downie
+  description: Team headshot of Katie Campbell Downie, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-katie-gwinn
+  path: katie-gwinn.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - katie-gwinn
+  alt: Headshot of Katie Gwinn
+  description: Team headshot of Katie Gwinn, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-katie-gwinn-2
+  path: katie-gwinn.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - katie-gwinn
+  alt: Headshot of Katie Gwinn
+  description: Team headshot of Katie Gwinn, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kelli-mason
+  path: kelli-mason.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kelli-mason
+  alt: Headshot of Kelli Mason
+  description: Team headshot of Kelli Mason, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kenneth-chow
+  path: kenneth-chow.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kenneth-chow
+  alt: Headshot of Kenneth Chow
+  description: Team headshot of Kenneth Chow, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kenneth-nieh
+  path: kenneth-nieh.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kenneth-nieh
+  alt: Headshot of Kenneth Nieh
+  description: Team headshot of Kenneth Nieh, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kenny-nieh
+  path: kenny-nieh.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kenny-nieh
+  alt: Headshot of Kenny Nieh
+  description: Team headshot of Kenny Nieh, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kevin-fiol
+  path: kevin-fiol.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kevin-fiol
+  alt: Headshot of Kevin Fiol
+  description: Team headshot of Kevin Fiol, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kevin-fiol-2
+  path: kevin-fiol.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kevin-fiol
+  alt: Headshot of Kevin Fiol
+  description: Team headshot of Kevin Fiol, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-khayeni-sanders
+  path: khayeni-sanders.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - khayeni-sanders
+  alt: Headshot of Khayeni Sanders
+  description: Team headshot of Khayeni Sanders, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-khayeni-sanders-2
+  path: khayeni-sanders.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - khayeni-sanders
+  alt: Headshot of Khayeni Sanders
+  description: Team headshot of Khayeni Sanders, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kim-connelly
+  path: kim-connelly.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kim-connelly
+  alt: Headshot of Kim Connelly
+  description: Team headshot of Kim Connelly, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kim-connelly-2
+  path: kim-connelly.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kim-connelly
+  alt: Headshot of Kim Connelly
+  description: Team headshot of Kim Connelly, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kin-lane
+  path: kin-lane.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kin-lane
+  alt: Headshot of Kin Lane
+  description: Team headshot of Kin Lane, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kyle-bond
+  path: kyle-bond.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kyle-bond
+  alt: Headshot of Kyle Bond
+  description: Team headshot of Kyle Bond, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kyle-bond-2
+  path: kyle-bond.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kyle-bond
+  alt: Headshot of Kyle Bond
+  description: Team headshot of Kyle Bond, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kyle-bond-3
+  path: kyle-bond.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kyle-bond
+  alt: Headshot of Kyle Bond
+  description: Team headshot of Kyle Bond, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kyle-magida
+  path: kyle-magida.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kyle-magida
+  alt: Headshot of Kyle Magida
+  description: Team headshot of Kyle Magida, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kyle-planeaux
+  path: kyle-planeaux.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kyle-planeaux
+  alt: Headshot of Kyle Planeaux
+  description: Team headshot of Kyle Planeaux, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kyle-planeaux-2
+  path: kyle-planeaux.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kyle-planeaux
+  alt: Headshot of Kyle Planeaux
+  description: Team headshot of Kyle Planeaux, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-kyle-planeaux-3
+  path: kyle-planeaux.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - kyle-planeaux
+  alt: Headshot of Kyle Planeaux
+  description: Team headshot of Kyle Planeaux, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-lainey-trahan
+  path: lainey-trahan.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - lainey-trahan
+  alt: Headshot of Lainey Trahan
+  description: Team headshot of Lainey Trahan, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-lara-kohl
+  path: lara-kohl.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - lara-kohl
+  alt: Headshot of Lara Kohl
+  description: Team headshot of Lara Kohl, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-laura-janisse
+  path: laura-janisse.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - laura-janisse
+  alt: Headshot of Laura Janisse
+  description: Team headshot of Laura Janisse, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-laura-janisse-2
+  path: laura-janisse.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - laura-janisse
+  alt: Headshot of Laura Janisse
+  description: Team headshot of Laura Janisse, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-laura-janisse-3
+  path: laura-janisse.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - laura-janisse
+  alt: Headshot of Laura Janisse
+  description: Team headshot of Laura Janisse, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-laura-kerry
+  path: laura-kerry.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - laura-kerry
+  alt: Headshot of Laura Kerry
+  description: Team headshot of Laura Kerry, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-laura-kerry-2
+  path: laura-kerry.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - laura-kerry
+  alt: Headshot of Laura Kerry
+  description: Team headshot of Laura Kerry, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-laura-kerry-3
+  path: laura-kerry.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - laura-kerry
+  alt: Headshot of Laura Kerry
+  description: Team headshot of Laura Kerry, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-laura-king
+  path: laura-king.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - laura-king
+  alt: Headshot of Laura King
+  description: Team headshot of Laura King, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-laura-king-2
+  path: laura-king.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - laura-king
+  alt: Headshot of Laura King
+  description: Team headshot of Laura King, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-laura-king-3
+  path: laura-king.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - laura-king
+  alt: Headshot of Laura King
+  description: Team headshot of Laura King, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-laurel-lawrence
+  path: laurel-lawrence.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - laurel-lawrence
+  alt: Headshot of Laurel Lawrence
+  description: Team headshot of Laurel Lawrence, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-laurel-lawrence-2
+  path: laurel-lawrence.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - laurel-lawrence
+  alt: Headshot of Laurel Lawrence
+  description: Team headshot of Laurel Lawrence, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-lauren-kieliszewski
+  path: lauren-kieliszewski.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - lauren-kieliszewski
+  alt: Headshot of Lauren Kieliszewski
+  description: Team headshot of Lauren Kieliszewski, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-lauren-kieliszewski-2
+  path: lauren-kieliszewski.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - lauren-kieliszewski
+  alt: Headshot of Lauren Kieliszewski
+  description: Team headshot of Lauren Kieliszewski, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-lauryn-claassen
+  path: lauryn-claassen.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - lauryn-claassen
+  alt: Headshot of Lauryn Claassen
+  description: Team headshot of Lauryn Claassen, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-lauryn-claassen-2
+  path: lauryn-claassen.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - lauryn-claassen
+  alt: Headshot of Lauryn Claassen
+  description: Team headshot of Lauryn Claassen, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-lauryn-claassen-3
+  path: lauryn-claassen.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - lauryn-claassen
+  alt: Headshot of Lauryn Claassen
+  description: Team headshot of Lauryn Claassen, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-leila-rassi
+  path: leila-rassi.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - leila-rassi
+  alt: Headshot of Leila Rassi
+  description: Team headshot of Leila Rassi, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-leila-rassi-2
+  path: leila-rassi.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - leila-rassi
+  alt: Headshot of Leila Rassi
+  description: Team headshot of Leila Rassi, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-lesley-evans
+  path: lesley-evans.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - lesley-evans
+  alt: Headshot of Lesley Evans
+  description: Team headshot of Lesley Evans, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-leslie-garner-franklin
+  path: leslie-garner-franklin.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - leslie-garner-franklin
+  alt: Headshot of Leslie Garner Franklin
+  description: Team headshot of Leslie Garner Franklin, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-leslie-garner-franklin-2
+  path: leslie-garner-franklin.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - leslie-garner-franklin
+  alt: Headshot of Leslie Garner Franklin
+  description: Team headshot of Leslie Garner Franklin, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-leslie-garner-franklin-3
+  path: leslie-garner-franklin.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - leslie-garner-franklin
+  alt: Headshot of Leslie Garner Franklin
+  description: Team headshot of Leslie Garner Franklin, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-lillian-tran
+  path: lillian-tran.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - lillian-tran
+  alt: Headshot of Lillian Tran
+  description: Team headshot of Lillian Tran, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-lillian-tran-2
+  path: lillian-tran.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - lillian-tran
+  alt: Headshot of Lillian Tran
+  description: Team headshot of Lillian Tran, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-lina-roth
+  path: lina-roth.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - lina-roth
+  alt: Headshot of Lina Roth
+  description: Team headshot of Lina Roth, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-lina-roth-2
+  path: lina-roth.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - lina-roth
+  alt: Headshot of Lina Roth
+  description: Team headshot of Lina Roth, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-liz-fox
+  path: liz-fox.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - liz-fox
+  alt: Headshot of Liz Fox
+  description: Team headshot of Liz Fox, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-lucas-newman
+  path: lucas-newman.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - lucas-newman
+  alt: Headshot of Lucas Newman
+  description: Team headshot of Lucas Newman, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-lucian-snare
+  path: lucian-snare.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - lucian-snare
+  alt: Headshot of Lucian Snare
+  description: Team headshot of Lucian Snare, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-lucian-snare-2
+  path: lucian-snare.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - lucian-snare
+  alt: Headshot of Lucian Snare
+  description: Team headshot of Lucian Snare, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mai-thao
+  path: mai-thao.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mai-thao
+  alt: Headshot of Mai Thao
+  description: Team headshot of Mai Thao, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mai-thao-2
+  path: mai-thao.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mai-thao
+  alt: Headshot of Mai Thao
+  description: Team headshot of Mai Thao, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-marcelle-goggins
+  path: marcelle-goggins.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - marcelle-goggins
+  alt: Headshot of Marcelle Goggins
+  description: Team headshot of Marcelle Goggins, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-marcelle-goggins-2
+  path: marcelle-goggins.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - marcelle-goggins
+  alt: Headshot of Marcelle Goggins
+  description: Team headshot of Marcelle Goggins, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-marcelle-goggins-3
+  path: marcelle-goggins.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - marcelle-goggins
+  alt: Headshot of Marcelle Goggins
+  description: Team headshot of Marcelle Goggins, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-marvo-dolor
+  path: marvo-dolor.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - marvo-dolor
+  alt: Headshot of Marvo Dolor
+  description: Team headshot of Marvo Dolor, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mary-crawford
+  path: mary-crawford.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mary-crawford
+  alt: Headshot of Mary Crawford
+  description: Team headshot of Mary Crawford, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mary-mcgrath
+  path: mary-mcgrath.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mary-mcgrath
+  alt: Headshot of Mary Mcgrath
+  description: Team headshot of Mary Mcgrath, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mary-mcgrath-2
+  path: mary-mcgrath.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mary-mcgrath
+  alt: Headshot of Mary Mcgrath
+  description: Team headshot of Mary Mcgrath, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mary-yeh
+  path: mary-yeh.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mary-yeh
+  alt: Headshot of Mary Yeh
+  description: Team headshot of Mary Yeh, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mary-yeh-2
+  path: mary-yeh.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mary-yeh
+  alt: Headshot of Mary Yeh
+  description: Team headshot of Mary Yeh, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mary-yeh-3
+  path: mary-yeh.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mary-yeh
+  alt: Headshot of Mary Yeh
+  description: Team headshot of Mary Yeh, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-matt-declercq
+  path: matt-declercq.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - matt-declercq
+  alt: Headshot of Matt Declercq
+  description: Team headshot of Matt Declercq, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-matt-declercq-2
+  path: matt-declercq.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - matt-declercq
+  alt: Headshot of Matt Declercq
+  description: Team headshot of Matt Declercq, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-matt-declercq-3
+  path: matt-declercq.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - matt-declercq
+  alt: Headshot of Matt Declercq
+  description: Team headshot of Matt Declercq, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-matt-dobson
+  path: matt-dobson.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - matt-dobson
+  alt: Headshot of Matt Dobson
+  description: Team headshot of Matt Dobson, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-matt-dobson-2
+  path: matt-dobson.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - matt-dobson
+  alt: Headshot of Matt Dobson
+  description: Team headshot of Matt Dobson, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-matt-goldberg
+  path: matt-goldberg.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - matt-goldberg
+  alt: Headshot of Matt Goldberg
+  description: Team headshot of Matt Goldberg, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-matt-goldberg-2
+  path: matt-goldberg.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - matt-goldberg
+  alt: Headshot of Matt Goldberg
+  description: Team headshot of Matt Goldberg, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-matt-goldberg-3
+  path: matt-goldberg.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - matt-goldberg
+  alt: Headshot of Matt Goldberg
+  description: Team headshot of Matt Goldberg, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-maurice-reeves
+  path: maurice-reeves.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - maurice-reeves
+  alt: Headshot of Maurice Reeves
+  description: Team headshot of Maurice Reeves, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-maurice-reeves-2
+  path: maurice-reeves.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - maurice-reeves
+  alt: Headshot of Maurice Reeves
+  description: Team headshot of Maurice Reeves, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-maya-benari
+  path: maya-benari.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - maya-benari
+  alt: Headshot of Maya Benari
+  description: Team headshot of Maya Benari, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-maya-mascarenhas
+  path: maya-mascarenhas.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - maya-mascarenhas
+  alt: Headshot of Maya Mascarenhas
+  description: Team headshot of Maya Mascarenhas, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-maya-mascarenhas-2
+  path: maya-mascarenhas.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - maya-mascarenhas
+  alt: Headshot of Maya Mascarenhas
+  description: Team headshot of Maya Mascarenhas, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-merethe-hansen
+  path: merethe-hansen.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - merethe-hansen
+  alt: Headshot of Merethe Hansen
+  description: Team headshot of Merethe Hansen, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-merethe-hansen-2
+  path: merethe-hansen.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - merethe-hansen
+  alt: Headshot of Merethe Hansen
+  description: Team headshot of Merethe Hansen, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-merethe-hansen-3
+  path: merethe-hansen.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - merethe-hansen
+  alt: Headshot of Merethe Hansen
+  description: Team headshot of Merethe Hansen, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mical-nobel
+  path: mical-nobel.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mical-nobel
+  alt: Headshot of Mical Nobel
+  description: Team headshot of Mical Nobel, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-michael-wales
+  path: michael-wales.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - michael-wales
+  alt: Headshot of Michael Wales
+  description: Team headshot of Michael Wales, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-michael-wales-2
+  path: michael-wales.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - michael-wales
+  alt: Headshot of Michael Wales
+  description: Team headshot of Michael Wales, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-michael-wales-3
+  path: michael-wales.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - michael-wales
+  alt: Headshot of Michael Wales
+  description: Team headshot of Michael Wales, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-michelle-kang
+  path: michelle-kang.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - michelle-kang
+  alt: Headshot of Michelle Kang
+  description: Team headshot of Michelle Kang, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-michelle-kang-2
+  path: michelle-kang.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - michelle-kang
+  alt: Headshot of Michelle Kang
+  description: Team headshot of Michelle Kang, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-michelle-li
+  path: michelle-li.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - michelle-li
+  alt: Headshot of Michelle Li
+  description: Team headshot of Michelle Li, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mike-brown
+  path: mike-brown.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mike-brown
+  alt: Headshot of Mike Brown
+  description: Team headshot of Mike Brown, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mike-brown-2
+  path: mike-brown.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mike-brown
+  alt: Headshot of Mike Brown
+  description: Team headshot of Mike Brown, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mike-brown-3
+  path: mike-brown.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mike-brown
+  alt: Headshot of Mike Brown
+  description: Team headshot of Mike Brown, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mike-henderson
+  path: mike-henderson.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mike-henderson
+  alt: Headshot of Mike Henderson
+  description: Team headshot of Mike Henderson, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mike-henderson-2
+  path: mike-henderson.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mike-henderson
+  alt: Headshot of Mike Henderson
+  description: Team headshot of Mike Henderson, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mike-judd
+  path: mike-judd.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mike-judd
+  alt: Headshot of Mike Judd
+  description: Team headshot of Mike Judd, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mike-judd-2
+  path: mike-judd.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mike-judd
+  alt: Headshot of Mike Judd
+  description: Team headshot of Mike Judd, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mike-judd-3
+  path: mike-judd.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mike-judd
+  alt: Headshot of Mike Judd
+  description: Team headshot of Mike Judd, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mina-cairns
+  path: mina-cairns.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mina-cairns
+  alt: Headshot of Mina Cairns
+  description: Team headshot of Mina Cairns, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mina-cairns-2
+  path: mina-cairns.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mina-cairns
+  alt: Headshot of Mina Cairns
+  description: Team headshot of Mina Cairns, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mina-cairns-3
+  path: mina-cairns.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mina-cairns
+  alt: Headshot of Mina Cairns
+  description: Team headshot of Mina Cairns, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mindy-huang
+  path: mindy-huang.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mindy-huang
+  alt: Headshot of Mindy Huang
+  description: Team headshot of Mindy Huang, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mindy-huang-2
+  path: mindy-huang.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mindy-huang
+  alt: Headshot of Mindy Huang
+  description: Team headshot of Mindy Huang, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-miringu-kiarie
+  path: miringu-kiarie.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - miringu-kiarie
+  alt: Headshot of Miringu Kiarie
+  description: Team headshot of Miringu Kiarie, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-miringu-kiarie-2
+  path: miringu-kiarie.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - miringu-kiarie
+  alt: Headshot of Miringu Kiarie
+  description: Team headshot of Miringu Kiarie, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-miringu-kiarie-3
+  path: miringu-kiarie.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - miringu-kiarie
+  alt: Headshot of Miringu Kiarie
+  description: Team headshot of Miringu Kiarie, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-mitchell-sipus
+  path: mitchell-sipus.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - mitchell-sipus
+  alt: Headshot of Mitchell Sipus
+  description: Team headshot of Mitchell Sipus, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-monica-qiu
+  path: monica-qiu.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - monica-qiu
+  alt: Headshot of Monica Qiu
+  description: Team headshot of Monica Qiu, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-monica-qiu-2
+  path: monica-qiu.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - monica-qiu
+  alt: Headshot of Monica Qiu
+  description: Team headshot of Monica Qiu, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-monica-qiu-3
+  path: monica-qiu.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - monica-qiu
+  alt: Headshot of Monica Qiu
+  description: Team headshot of Monica Qiu, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-nathan-carter
+  path: nathan-carter.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - nathan-carter
+  alt: Headshot of Nathan Carter
+  description: Team headshot of Nathan Carter, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-nathan-carter-2
+  path: nathan-carter.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - nathan-carter
+  alt: Headshot of Nathan Carter
+  description: Team headshot of Nathan Carter, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-nathan-carter-3
+  path: nathan-carter.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - nathan-carter
+  alt: Headshot of Nathan Carter
+  description: Team headshot of Nathan Carter, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-nick-blake
+  path: nick-blake.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - nick-blake
+  alt: Headshot of Nick Blake
+  description: Team headshot of Nick Blake, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-nick-blake-2
+  path: nick-blake.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - nick-blake
+  alt: Headshot of Nick Blake
+  description: Team headshot of Nick Blake, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-nick-blake-3
+  path: nick-blake.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - nick-blake
+  alt: Headshot of Nick Blake
+  description: Team headshot of Nick Blake, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-nick-bristow
+  path: nick-bristow.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - nick-bristow
+  alt: Headshot of Nick Bristow
+  description: Team headshot of Nick Bristow, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-nick-bristow-2
+  path: nick-bristow.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - nick-bristow
+  alt: Headshot of Nick Bristow
+  description: Team headshot of Nick Bristow, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-nick-bristow-3
+  path: nick-bristow.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - nick-bristow
+  alt: Headshot of Nick Bristow
+  description: Team headshot of Nick Bristow, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-nick-clyde
+  path: nick-clyde.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - nick-clyde
+  alt: Headshot of Nick Clyde
+  description: Team headshot of Nick Clyde, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-nick-clyde-2
+  path: nick-clyde.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - nick-clyde
+  alt: Headshot of Nick Clyde
+  description: Team headshot of Nick Clyde, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-nick-clyde-3
+  path: nick-clyde.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - nick-clyde
+  alt: Headshot of Nick Clyde
+  description: Team headshot of Nick Clyde, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-nick-raeon
+  path: nick-raeon.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - nick-raeon
+  alt: Headshot of Nick Raeon
+  description: Team headshot of Nick Raeon, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-nick-raeon-2
+  path: nick-raeon.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - nick-raeon
+  alt: Headshot of Nick Raeon
+  description: Team headshot of Nick Raeon, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-nicole-campbell
+  path: nicole-campbell.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - nicole-campbell
+  alt: Headshot of Nicole Campbell
+  description: Team headshot of Nicole Campbell, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-nicole-campbell-2
+  path: nicole-campbell.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - nicole-campbell
+  alt: Headshot of Nicole Campbell
+  description: Team headshot of Nicole Campbell, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-nicole-campbell-3
+  path: nicole-campbell.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - nicole-campbell
+  alt: Headshot of Nicole Campbell
+  description: Team headshot of Nicole Campbell, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-nicole-wright
+  path: nicole-wright.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - nicole-wright
+  alt: Headshot of Nicole Wright
+  description: Team headshot of Nicole Wright, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-olivia-lucas
+  path: olivia-lucas.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - olivia-lucas
+  alt: Headshot of Olivia Lucas
+  description: Team headshot of Olivia Lucas, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-ori-hoffer
+  path: ori-hoffer.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - ori-hoffer
+  alt: Headshot of Ori Hoffer
+  description: Team headshot of Ori Hoffer, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-peggy-chau
+  path: peggy-chau.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - peggy-chau
+  alt: Headshot of Peggy Chau
+  description: Team headshot of Peggy Chau, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-peggy-chau-2
+  path: peggy-chau.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - peggy-chau
+  alt: Headshot of Peggy Chau
+  description: Team headshot of Peggy Chau, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-peggy-chau-3
+  path: peggy-chau.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - peggy-chau
+  alt: Headshot of Peggy Chau
+  description: Team headshot of Peggy Chau, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-phoebe-espiritu
+  path: phoebe-espiritu.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - phoebe-espiritu
+  alt: Headshot of Phoebe Espiritu
+  description: Team headshot of Phoebe Espiritu, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-pri-kiser
+  path: pri-kiser.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - pri-kiser
+  alt: Headshot of Pri Kiser
+  description: Team headshot of Pri Kiser, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-pri-kiser-2
+  path: pri-kiser.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - pri-kiser
+  alt: Headshot of Pri Kiser
+  description: Team headshot of Pri Kiser, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-pri-kiser-3
+  path: pri-kiser.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - pri-kiser
+  alt: Headshot of Pri Kiser
+  description: Team headshot of Pri Kiser, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-priscilla-peralta
+  path: priscilla-peralta.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - priscilla-peralta
+  alt: Headshot of Priscilla Peralta
+  description: Team headshot of Priscilla Peralta, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-randall-rupp
+  path: randall-rupp.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - randall-rupp
+  alt: Headshot of Randall Rupp
+  description: Team headshot of Randall Rupp, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-randall-rupp-2
+  path: randall-rupp.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - randall-rupp
+  alt: Headshot of Randall Rupp
+  description: Team headshot of Randall Rupp, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-rebecca-lubitzmarchena
+  path: rebecca-lubitzmarchena.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - rebecca-lubitzmarchena
+  alt: Headshot of Rebecca Lubitzmarchena
+  description: Team headshot of Rebecca Lubitzmarchena, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-rebecca-lubitzmarchena-2
+  path: rebecca-lubitzmarchena.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - rebecca-lubitzmarchena
+  alt: Headshot of Rebecca Lubitzmarchena
+  description: Team headshot of Rebecca Lubitzmarchena, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-rin-concordia
+  path: rin-concordia.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - rin-concordia
+  alt: Headshot of Rin Concordia
+  description: Team headshot of Rin Concordia, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-rob-mitchell
+  path: rob-mitchell.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - rob-mitchell
+  alt: Headshot of Rob Mitchell
+  description: Team headshot of Rob Mitchell, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-rob-mitchell-2
+  path: rob-mitchell.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - rob-mitchell
+  alt: Headshot of Rob Mitchell
+  description: Team headshot of Rob Mitchell, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-robert-mitchell
+  path: robert-mitchell.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - robert-mitchell
+  alt: Headshot of Robert Mitchell
+  description: Team headshot of Robert Mitchell, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-robert-mitchell-2
+  path: robert-mitchell.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - robert-mitchell
+  alt: Headshot of Robert Mitchell
+  description: Team headshot of Robert Mitchell, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-robert-mitchell-3
+  path: robert-mitchell.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - robert-mitchell
+  alt: Headshot of Robert Mitchell
+  description: Team headshot of Robert Mitchell, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-robert-read
+  path: robert-read.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - robert-read
+  alt: Headshot of Robert Read
+  description: Team headshot of Robert Read, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-robert-read-2
+  path: robert-read.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - robert-read
+  alt: Headshot of Robert Read
+  description: Team headshot of Robert Read, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-robert-read-3
+  path: robert-read.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - robert-read
+  alt: Headshot of Robert Read
+  description: Team headshot of Robert Read, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-roger-ruiz
+  path: roger-ruiz.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - roger-ruiz
+  alt: Headshot of Roger Ruiz
+  description: Team headshot of Roger Ruiz, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-roger-ruiz-2
+  path: roger-ruiz.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - roger-ruiz
+  alt: Headshot of Roger Ruiz
+  description: Team headshot of Roger Ruiz, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-roger-ruiz-3
+  path: roger-ruiz.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - roger-ruiz
+  alt: Headshot of Roger Ruiz
+  description: Team headshot of Roger Ruiz, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-ruby-mccafferty
+  path: ruby-mccafferty.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - ruby-mccafferty
+  alt: Headshot of Ruby Mccafferty
+  description: Team headshot of Ruby Mccafferty, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-ruby-mccafferty-2
+  path: ruby-mccafferty.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - ruby-mccafferty
+  alt: Headshot of Ruby Mccafferty
+  description: Team headshot of Ruby Mccafferty, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-ryan-gaddis
+  path: ryan-gaddis.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - ryan-gaddis
+  alt: Headshot of Ryan Gaddis
+  description: Team headshot of Ryan Gaddis, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-sarah-george-hager
+  path: sarah-george-hager.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - sarah-george-hager
+  alt: Headshot of Sarah George Hager
+  description: Team headshot of Sarah George Hager, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-sarah-tress
+  path: sarah-tress.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - sarah-tress
+  alt: Headshot of Sarah Tress
+  description: Team headshot of Sarah Tress, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-sarah-tress-2
+  path: sarah-tress.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - sarah-tress
+  alt: Headshot of Sarah Tress
+  description: Team headshot of Sarah Tress, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-sarah-tress-3
+  path: sarah-tress.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - sarah-tress
+  alt: Headshot of Sarah Tress
+  description: Team headshot of Sarah Tress, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-scott-hallman
+  path: scott-hallman.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - scott-hallman
+  alt: Headshot of Scott Hallman
+  description: Team headshot of Scott Hallman, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-scott-hallman-2
+  path: scott-hallman.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - scott-hallman
+  alt: Headshot of Scott Hallman
+  description: Team headshot of Scott Hallman, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-sean-johnson
+  path: sean-johnson.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - sean-johnson
+  alt: Headshot of Sean Johnson
+  description: Team headshot of Sean Johnson, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-sean-johnson-2
+  path: sean-johnson.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - sean-johnson
+  alt: Headshot of Sean Johnson
+  description: Team headshot of Sean Johnson, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-sean-johnson-3
+  path: sean-johnson.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - sean-johnson
+  alt: Headshot of Sean Johnson
+  description: Team headshot of Sean Johnson, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-shashank-khandelwal
+  path: shashank-khandelwal.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - shashank-khandelwal
+  alt: Headshot of Shashank Khandelwal
+  description: Team headshot of Shashank Khandelwal, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-spencer-kathol
+  path: spencer-kathol.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - spencer-kathol
+  alt: Headshot of Spencer Kathol
+  description: Team headshot of Spencer Kathol, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-stephen-chow
+  path: stephen-chow.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - stephen-chow
+  alt: Headshot of Stephen Chow
+  description: Team headshot of Stephen Chow, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-stephen-morrison
+  path: stephen-morrison.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - stephen-morrison
+  alt: Headshot of Stephen Morrison
+  description: Team headshot of Stephen Morrison, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-stephen-morrison-2
+  path: stephen-morrison.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - stephen-morrison
+  alt: Headshot of Stephen Morrison
+  description: Team headshot of Stephen Morrison, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-steven-speck
+  path: steven-speck.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - steven-speck
+  alt: Headshot of Steven Speck
+  description: Team headshot of Steven Speck, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-suzanne-chapman
+  path: suzanne-chapman.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - suzanne-chapman
+  alt: Headshot of Suzanne Chapman
+  description: Team headshot of Suzanne Chapman, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-taylor-graue
+  path: taylor-graue.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - taylor-graue
+  alt: Headshot of Taylor Graue
+  description: Team headshot of Taylor Graue, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-taylor-graue-2
+  path: taylor-graue.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - taylor-graue
+  alt: Headshot of Taylor Graue
+  description: Team headshot of Taylor Graue, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-taylor-graue-3
+  path: taylor-graue.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - taylor-graue
+  alt: Headshot of Taylor Graue
+  description: Team headshot of Taylor Graue, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-tiffany-nieh
+  path: tiffany-nieh.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - tiffany-nieh
+  alt: Headshot of Tiffany Nieh
+  description: Team headshot of Tiffany Nieh, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-tiffany-nieh-2
+  path: tiffany-nieh.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - tiffany-nieh
+  alt: Headshot of Tiffany Nieh
+  description: Team headshot of Tiffany Nieh, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-tiffany-nieh-3
+  path: tiffany-nieh.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - tiffany-nieh
+  alt: Headshot of Tiffany Nieh
+  description: Team headshot of Tiffany Nieh, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-tim-niehoff
+  path: tim-niehoff.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - tim-niehoff
+  alt: Headshot of Tim Niehoff
+  description: Team headshot of Tim Niehoff, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-tom-black
+  path: tom-black.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - tom-black
+  alt: Headshot of Tom Black
+  description: Team headshot of Tom Black, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-tomi-obikunle
+  path: tomi-obikunle.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - tomi-obikunle
+  alt: Headshot of Tomi Obikunle
+  description: Team headshot of Tomi Obikunle, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-tomi-obikunle-2
+  path: tomi-obikunle.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - tomi-obikunle
+  alt: Headshot of Tomi Obikunle
+  description: Team headshot of Tomi Obikunle, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-tomi-obikunle-3
+  path: tomi-obikunle.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - tomi-obikunle
+  alt: Headshot of Tomi Obikunle
+  description: Team headshot of Tomi Obikunle, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-victor-zapanta
+  path: victor-zapanta.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - victor-zapanta
+  alt: Headshot of Victor Zapanta
+  description: Team headshot of Victor Zapanta, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-victoria-suwardiman
+  path: victoria-suwardiman.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - victoria-suwardiman
+  alt: Headshot of Victoria Suwardiman
+  description: Team headshot of Victoria Suwardiman, from skylight.digital's people/team
+    pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-will-conant
+  path: will-conant.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - will-conant
+  alt: Headshot of Will Conant
+  description: Team headshot of Will Conant, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-will-conant-2
+  path: will-conant.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - will-conant
+  alt: Headshot of Will Conant
+  description: Team headshot of Will Conant, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-zach-thomas
+  path: zach-thomas.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - zach-thomas
+  alt: Headshot of Zach Thomas
+  description: Team headshot of Zach Thomas, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-zach-thomas-2
+  path: zach-thomas.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - zach-thomas
+  alt: Headshot of Zach Thomas
+  description: Team headshot of Zach Thomas, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-zack-gehin
+  path: zack-gehin.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - zack-gehin
+  alt: Headshot of Zack Gehin
+  description: Team headshot of Zack Gehin, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-zack-gehin-2
+  path: zack-gehin.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - zack-gehin
+  alt: Headshot of Zack Gehin
+  description: Team headshot of Zack Gehin, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-zack-gehin-3
+  path: zack-gehin.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - zack-gehin
+  alt: Headshot of Zack Gehin
+  description: Team headshot of Zack Gehin, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-zedd-shmais
+  path: zedd-shmais.jpg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - zedd-shmais
+  alt: Headshot of Zedd Shmais
+  description: Team headshot of Zedd Shmais, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-zedd-shmais-2
+  path: zedd-shmais.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - zedd-shmais
+  alt: Headshot of Zedd Shmais
+  description: Team headshot of Zedd Shmais, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-zedd-shmais-3
+  path: zedd-shmais.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - zedd-shmais
+  alt: Headshot of Zedd Shmais
+  description: Team headshot of Zedd Shmais, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: person-zoe-do
+  path: zoe-do.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: headshot
+  themes:
+  - team
+  tags: []
+  people:
+  - zoe-do
+  alt: Headshot of Zoe Do
+  description: Team headshot of Zoe Do, from skylight.digital's people/team pages.
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false

--- a/img/projects/assets-manifest.yml
+++ b/img/projects/assets-manifest.yml
@@ -1,0 +1,2984 @@
+# Federation asset manifest -- skylight.digital img/projects (Phase C.2).
+# Path-derived enrichment; all assets are Skylight's own on the public site
+# -> permissions: skylight-owned, classification: public. ids are path-based.
+# NOTE: judgment fields the team should refine -- which people are current vs.
+# former (archive those), client/mission tags per project, and richer alt text.
+- id: project-18f-consulting-digital-mastery
+  path: 18f_consulting/digital-mastery.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - 18f-consulting
+  alt: '18f Consulting case study: Digital Mastery'
+  description: Case-study graphic for the 18f Consulting project (Digital Mastery).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-18f-consulting-digital-mastery-2
+  path: 18f_consulting/digital-mastery.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - 18f-consulting
+  alt: '18f Consulting case study: Digital Mastery'
+  description: Case-study graphic for the 18f Consulting project (Digital Mastery).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-acme-devops-transformation-devops
+  path: acme_devops_transformation/devops.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - acme-devops-transformation
+  alt: 'Acme Devops Transformation case study: Devops'
+  description: Case-study graphic for the Acme Devops Transformation project (Devops).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-acme-devops-transformation-devops-2
+  path: acme_devops_transformation/devops.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - acme-devops-transformation
+  alt: 'Acme Devops Transformation case study: Devops'
+  description: Case-study graphic for the Acme Devops Transformation project (Devops).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-adopta-agency-api-launcher
+  path: adopta_agency/api-launcher.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - adopta-agency
+  alt: 'Adopta Agency case study: Api Launcher'
+  description: Case-study graphic for the Adopta Agency project (Api Launcher).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-adopta-agency-api-launcher-2
+  path: adopta_agency/api-launcher.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - adopta-agency
+  alt: 'Adopta Agency case study: Api Launcher'
+  description: Case-study graphic for the Adopta Agency project (Api Launcher).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-agile-acquisition-framework-agile-acquisition-framework
+  path: agile_acquisition_framework/agile-acquisition-framework.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - agile-acquisition-framework
+  alt: 'Agile Acquisition Framework case study: Agile Acquisition Framework'
+  description: Case-study graphic for the Agile Acquisition Framework project (Agile
+    Acquisition Framework).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-agile-acquisition-framework-agile-acquisition-framework-2
+  path: agile_acquisition_framework/agile-acquisition-framework.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - agile-acquisition-framework
+  alt: 'Agile Acquisition Framework case study: Agile Acquisition Framework'
+  description: Case-study graphic for the Agile Acquisition Framework project (Agile
+    Acquisition Framework).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-agile-delivery-services-marketplace-agile-delivery-services-marketplace
+  path: agile_delivery_services_marketplace/agile-delivery-services-marketplace.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - agile-delivery-services-marketplace
+  alt: 'Agile Delivery Services Marketplace case study: Agile Delivery Services Marketplace'
+  description: Case-study graphic for the Agile Delivery Services Marketplace project
+    (Agile Delivery Services Marketplace).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-agile-delivery-services-marketplace-agile-delivery-services-marketplace-2
+  path: agile_delivery_services_marketplace/agile-delivery-services-marketplace.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - agile-delivery-services-marketplace
+  alt: 'Agile Delivery Services Marketplace case study: Agile Delivery Services Marketplace'
+  description: Case-study graphic for the Agile Delivery Services Marketplace project
+    (Agile Delivery Services Marketplace).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ca-hhs-agile-training-agile-training
+  path: ca_hhs_agile_training/agile-training.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ca-hhs-agile-training
+  alt: 'Ca Hhs Agile Training case study: Agile Training'
+  description: Case-study graphic for the Ca Hhs Agile Training project (Agile Training).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ca-hhs-agile-training-agile-training-2
+  path: ca_hhs_agile_training/agile-training.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ca-hhs-agile-training
+  alt: 'Ca Hhs Agile Training case study: Agile Training'
+  description: Case-study graphic for the Ca Hhs Agile Training project (Agile Training).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-carrot-carrot-demo-page
+  path: carrot/carrot-demo-page.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - carrot
+  alt: 'Carrot case study: Carrot Demo Page'
+  description: Case-study graphic for the Carrot project (Carrot Demo Page).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-carrot-carrot
+  path: carrot/carrot.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - carrot
+  alt: 'Carrot case study: Carrot'
+  description: Case-study graphic for the Carrot project (Carrot).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-carrot-carrot-2
+  path: carrot/carrot.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - carrot
+  alt: 'Carrot case study: Carrot'
+  description: Case-study graphic for the Carrot project (Carrot).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cdc-dibbs-dibbs-logo
+  path: cdc_dibbs/dibbs-logo.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cdc-dibbs
+  alt: 'Cdc Dibbs case study: Dibbs Logo'
+  description: Case-study graphic for the Cdc Dibbs project (Dibbs Logo).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cdc-dibbs-dibbs-logo-2
+  path: cdc_dibbs/dibbs-logo.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cdc-dibbs
+  alt: 'Cdc Dibbs case study: Dibbs Logo'
+  description: Case-study graphic for the Cdc Dibbs project (Dibbs Logo).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cdc-dibbs-dibbs
+  path: cdc_dibbs/dibbs.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cdc-dibbs
+  alt: 'Cdc Dibbs case study: Dibbs'
+  description: Case-study graphic for the Cdc Dibbs project (Dibbs).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cdc-dibbs-dibbs-2
+  path: cdc_dibbs/dibbs.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cdc-dibbs
+  alt: 'Cdc Dibbs case study: Dibbs'
+  description: Case-study graphic for the Cdc Dibbs project (Dibbs).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cdc-dibbs-cloud-enablement-dibbs-cloud-enablement
+  path: cdc_dibbs_cloud_enablement/dibbs-cloud-enablement.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cdc-dibbs-cloud-enablement
+  alt: 'Cdc Dibbs Cloud Enablement case study: Dibbs Cloud Enablement'
+  description: Case-study graphic for the Cdc Dibbs Cloud Enablement project (Dibbs
+    Cloud Enablement).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cdc-dibbs-cloud-enablement-dibbs-cloud-enablement-2
+  path: cdc_dibbs_cloud_enablement/dibbs-cloud-enablement.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cdc-dibbs-cloud-enablement
+  alt: 'Cdc Dibbs Cloud Enablement case study: Dibbs Cloud Enablement'
+  description: Case-study graphic for the Cdc Dibbs Cloud Enablement project (Dibbs
+    Cloud Enablement).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cdc-dibbs-ecr-viewer-dibbs-ecr-viewer
+  path: cdc_dibbs_ecr_viewer/dibbs-ecr-viewer.gif
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cdc-dibbs-ecr-viewer
+  alt: 'Cdc Dibbs Ecr Viewer case study: Dibbs Ecr Viewer'
+  description: Case-study graphic for the Cdc Dibbs Ecr Viewer project (Dibbs Ecr
+    Viewer).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cdc-dibbs-ecr-viewer-dibbs-ecr-viewer-2
+  path: cdc_dibbs_ecr_viewer/dibbs-ecr-viewer.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cdc-dibbs-ecr-viewer
+  alt: 'Cdc Dibbs Ecr Viewer case study: Dibbs Ecr Viewer'
+  description: Case-study graphic for the Cdc Dibbs Ecr Viewer project (Dibbs Ecr
+    Viewer).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cdc-dibbs-ecr-viewer-dibbs-ecr-viewer-3
+  path: cdc_dibbs_ecr_viewer/dibbs-ecr-viewer.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cdc-dibbs-ecr-viewer
+  alt: 'Cdc Dibbs Ecr Viewer case study: Dibbs Ecr Viewer'
+  description: Case-study graphic for the Cdc Dibbs Ecr Viewer project (Dibbs Ecr
+    Viewer).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cdc-dibbs-lac-pilot-dibbs-pipeline
+  path: cdc_dibbs_lac_pilot/dibbs-pipeline.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cdc-dibbs-lac-pilot
+  alt: 'Cdc Dibbs Lac Pilot case study: Dibbs Pipeline'
+  description: Case-study graphic for the Cdc Dibbs Lac Pilot project (Dibbs Pipeline).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cdc-dibbs-lac-pilot-dibbs-pipeline-2
+  path: cdc_dibbs_lac_pilot/dibbs-pipeline.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cdc-dibbs-lac-pilot
+  alt: 'Cdc Dibbs Lac Pilot case study: Dibbs Pipeline'
+  description: Case-study graphic for the Cdc Dibbs Lac Pilot project (Dibbs Pipeline).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cdc-dibbs-vdh-pilot-dibbs-vdh-prototype
+  path: cdc_dibbs_vdh_pilot/dibbs-vdh-prototype.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cdc-dibbs-vdh-pilot
+  alt: 'Cdc Dibbs Vdh Pilot case study: Dibbs Vdh Prototype'
+  description: Case-study graphic for the Cdc Dibbs Vdh Pilot project (Dibbs Vdh Prototype).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cdc-dibbs-vdh-pilot-dibbs-vdh-prototype-2
+  path: cdc_dibbs_vdh_pilot/dibbs-vdh-prototype.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cdc-dibbs-vdh-pilot
+  alt: 'Cdc Dibbs Vdh Pilot case study: Dibbs Vdh Prototype'
+  description: Case-study graphic for the Cdc Dibbs Vdh Pilot project (Dibbs Vdh Prototype).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cdc-simplereport-cdc-simplereport-alt
+  path: cdc_simplereport/cdc-simplereport-alt.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cdc-simplereport
+  alt: 'Cdc Simplereport case study: Cdc Simplereport Alt'
+  description: Case-study graphic for the Cdc Simplereport project (Cdc Simplereport
+    Alt).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cdc-simplereport-cdc-simplereport-alt-2
+  path: cdc_simplereport/cdc-simplereport-alt.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cdc-simplereport
+  alt: 'Cdc Simplereport case study: Cdc Simplereport Alt'
+  description: Case-study graphic for the Cdc Simplereport project (Cdc Simplereport
+    Alt).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cdc-simplereport-cdc-simplereport
+  path: cdc_simplereport/cdc-simplereport.gif
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cdc-simplereport
+  alt: 'Cdc Simplereport case study: Cdc Simplereport'
+  description: Case-study graphic for the Cdc Simplereport project (Cdc Simplereport).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cdc-simplereport-cdc-simplereport-2
+  path: cdc_simplereport/cdc-simplereport.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cdc-simplereport
+  alt: 'Cdc Simplereport case study: Cdc Simplereport'
+  description: Case-study graphic for the Cdc Simplereport project (Cdc Simplereport).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cdc-simplereport-cdc-simplereport-3
+  path: cdc_simplereport/cdc-simplereport.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cdc-simplereport
+  alt: 'Cdc Simplereport case study: Cdc Simplereport'
+  description: Case-study graphic for the Cdc Simplereport project (Cdc Simplereport).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cms-chart-model-idos
+  path: cms_chart_model/idos.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cms-chart-model
+  alt: 'Cms Chart Model case study: Idos'
+  description: Case-study graphic for the Cms Chart Model project (Idos).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cms-chart-model-idos-2
+  path: cms_chart_model/idos.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cms-chart-model
+  alt: 'Cms Chart Model case study: Idos'
+  description: Case-study graphic for the Cms Chart Model project (Idos).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cms-chart-model-rural-hospital-closures-map
+  path: cms_chart_model/rural-hospital-closures-map.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cms-chart-model
+  alt: 'Cms Chart Model case study: Rural Hospital Closures Map'
+  description: Case-study graphic for the Cms Chart Model project (Rural Hospital
+    Closures Map).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cms-chart-model-rural-hospital-closures-map-2
+  path: cms_chart_model/rural-hospital-closures-map.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cms-chart-model
+  alt: 'Cms Chart Model case study: Rural Hospital Closures Map'
+  description: Case-study graphic for the Cms Chart Model project (Rural Hospital
+    Closures Map).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cms-cmmi-idos-idos-tranformation
+  path: cms_cmmi_idos/idos-tranformation.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cms-cmmi-idos
+  alt: 'Cms Cmmi Idos case study: Idos Tranformation'
+  description: Case-study graphic for the Cms Cmmi Idos project (Idos Tranformation).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cms-cmmi-idos-idos-transformation
+  path: cms_cmmi_idos/idos-transformation.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cms-cmmi-idos
+  alt: 'Cms Cmmi Idos case study: Idos Transformation'
+  description: Case-study graphic for the Cms Cmmi Idos project (Idos Transformation).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cms-iqies-iqies
+  path: cms_iqies/iqies.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cms-iqies
+  alt: 'Cms Iqies case study: Iqies'
+  description: Case-study graphic for the Cms Iqies project (Iqies).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cms-iqies-iqies-2
+  path: cms_iqies/iqies.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cms-iqies
+  alt: 'Cms Iqies case study: Iqies'
+  description: Case-study graphic for the Cms Iqies project (Iqies).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cms-macbis-transformation-macbis
+  path: cms_macbis_transformation/macbis.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cms-macbis-transformation
+  alt: 'Cms Macbis Transformation case study: Macbis'
+  description: Case-study graphic for the Cms Macbis Transformation project (Macbis).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-cms-macbis-transformation-macbis-2
+  path: cms_macbis_transformation/macbis.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - cms-macbis-transformation
+  alt: 'Cms Macbis Transformation case study: Macbis'
+  description: Case-study graphic for the Cms Macbis Transformation project (Macbis).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-ece-reporter-ece-reporter-alt
+  path: ct_ece_reporter/ece-reporter-alt.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-ece-reporter
+  alt: 'Ct Ece Reporter case study: Ece Reporter Alt'
+  description: Case-study graphic for the Ct Ece Reporter project (Ece Reporter Alt).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-ece-reporter-ece-reporter-alt-2
+  path: ct_ece_reporter/ece-reporter-alt.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-ece-reporter
+  alt: 'Ct Ece Reporter case study: Ece Reporter Alt'
+  description: Case-study graphic for the Ct Ece Reporter project (Ece Reporter Alt).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-ece-reporter-ece-reporter
+  path: ct_ece_reporter/ece-reporter.gif
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-ece-reporter
+  alt: 'Ct Ece Reporter case study: Ece Reporter'
+  description: Case-study graphic for the Ct Ece Reporter project (Ece Reporter).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-ece-reporter-ece-reporter-2
+  path: ct_ece_reporter/ece-reporter.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-ece-reporter
+  alt: 'Ct Ece Reporter case study: Ece Reporter'
+  description: Case-study graphic for the Ct Ece Reporter project (Ece Reporter).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-ece-reporter-ece-reporter-3
+  path: ct_ece_reporter/ece-reporter.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-ece-reporter
+  alt: 'Ct Ece Reporter case study: Ece Reporter'
+  description: Case-study graphic for the Ct Ece Reporter project (Ece Reporter).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-families-experiencing-homelessness-families-experiencing-homelessness
+  path: ct_families_experiencing_homelessness/families-experiencing-homelessness.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-families-experiencing-homelessness
+  alt: 'Ct Families Experiencing Homelessness case study: Families Experiencing Homelessness'
+  description: Case-study graphic for the Ct Families Experiencing Homelessness project
+    (Families Experiencing Homelessness).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-families-experiencing-homelessness-families-experiencing-homelessness-2
+  path: ct_families_experiencing_homelessness/families-experiencing-homelessness.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-families-experiencing-homelessness
+  alt: 'Ct Families Experiencing Homelessness case study: Families Experiencing Homelessness'
+  description: Case-study graphic for the Ct Families Experiencing Homelessness project
+    (Families Experiencing Homelessness).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-care4kids-auto-notifier-care4kids-auto-notifier-alt-01
+  path: ct_oec_care4kids_auto_notifier/care4kids-auto-notifier-alt-01.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-care4kids-auto-notifier
+  alt: 'Ct Oec Care4kids Auto Notifier case study: Care4kids Auto Notifier Alt 01'
+  description: Case-study graphic for the Ct Oec Care4kids Auto Notifier project (Care4kids
+    Auto Notifier Alt 01).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-care4kids-auto-notifier-care4kids-auto-notifier-alt-01-2
+  path: ct_oec_care4kids_auto_notifier/care4kids-auto-notifier-alt-01.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-care4kids-auto-notifier
+  alt: 'Ct Oec Care4kids Auto Notifier case study: Care4kids Auto Notifier Alt 01'
+  description: Case-study graphic for the Ct Oec Care4kids Auto Notifier project (Care4kids
+    Auto Notifier Alt 01).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-care4kids-auto-notifier-care4kids-auto-notifier-alt-02
+  path: ct_oec_care4kids_auto_notifier/care4kids-auto-notifier-alt-02.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-care4kids-auto-notifier
+  alt: 'Ct Oec Care4kids Auto Notifier case study: Care4kids Auto Notifier Alt 02'
+  description: Case-study graphic for the Ct Oec Care4kids Auto Notifier project (Care4kids
+    Auto Notifier Alt 02).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-care4kids-auto-notifier-care4kids-auto-notifier-alt-02-2
+  path: ct_oec_care4kids_auto_notifier/care4kids-auto-notifier-alt-02.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-care4kids-auto-notifier
+  alt: 'Ct Oec Care4kids Auto Notifier case study: Care4kids Auto Notifier Alt 02'
+  description: Case-study graphic for the Ct Oec Care4kids Auto Notifier project (Care4kids
+    Auto Notifier Alt 02).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-care4kids-auto-notifier-care4kids-auto-notifier
+  path: ct_oec_care4kids_auto_notifier/care4kids-auto-notifier.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-care4kids-auto-notifier
+  alt: 'Ct Oec Care4kids Auto Notifier case study: Care4kids Auto Notifier'
+  description: Case-study graphic for the Ct Oec Care4kids Auto Notifier project (Care4kids
+    Auto Notifier).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-care4kids-auto-notifier-care4kids-auto-notifier-2
+  path: ct_oec_care4kids_auto_notifier/care4kids-auto-notifier.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-care4kids-auto-notifier
+  alt: 'Ct Oec Care4kids Auto Notifier case study: Care4kids Auto Notifier'
+  description: Case-study graphic for the Ct Oec Care4kids Auto Notifier project (Care4kids
+    Auto Notifier).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-transformation-early-childhood-services-transformation-alt-01
+  path: ct_oec_transformation/early-childhood-services-transformation-alt-01.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-transformation
+  alt: 'Ct Oec Transformation case study: Early Childhood Services Transformation
+    Alt 01'
+  description: Case-study graphic for the Ct Oec Transformation project (Early Childhood
+    Services Transformation Alt 01).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-transformation-early-childhood-services-transformation-alt-01-2
+  path: ct_oec_transformation/early-childhood-services-transformation-alt-01.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-transformation
+  alt: 'Ct Oec Transformation case study: Early Childhood Services Transformation
+    Alt 01'
+  description: Case-study graphic for the Ct Oec Transformation project (Early Childhood
+    Services Transformation Alt 01).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-transformation-early-childhood-services-transformation-alt-02
+  path: ct_oec_transformation/early-childhood-services-transformation-alt-02.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-transformation
+  alt: 'Ct Oec Transformation case study: Early Childhood Services Transformation
+    Alt 02'
+  description: Case-study graphic for the Ct Oec Transformation project (Early Childhood
+    Services Transformation Alt 02).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-transformation-early-childhood-services-transformation-alt-02-2
+  path: ct_oec_transformation/early-childhood-services-transformation-alt-02.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-transformation
+  alt: 'Ct Oec Transformation case study: Early Childhood Services Transformation
+    Alt 02'
+  description: Case-study graphic for the Ct Oec Transformation project (Early Childhood
+    Services Transformation Alt 02).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-transformation-early-childhood-services-transformation
+  path: ct_oec_transformation/early-childhood-services-transformation.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-transformation
+  alt: 'Ct Oec Transformation case study: Early Childhood Services Transformation'
+  description: Case-study graphic for the Ct Oec Transformation project (Early Childhood
+    Services Transformation).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-transformation-early-childhood-services-transformation-2
+  path: ct_oec_transformation/early-childhood-services-transformation.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-transformation
+  alt: 'Ct Oec Transformation case study: Early Childhood Services Transformation'
+  description: Case-study graphic for the Ct Oec Transformation project (Early Childhood
+    Services Transformation).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-transformation-oec-digital-transformation
+  path: ct_oec_transformation/oec-digital-transformation.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-transformation
+  alt: 'Ct Oec Transformation case study: Oec Digital Transformation'
+  description: Case-study graphic for the Ct Oec Transformation project (Oec Digital
+    Transformation).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-transformation-oec-digital-transformation-2
+  path: ct_oec_transformation/oec-digital-transformation.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-transformation
+  alt: 'Ct Oec Transformation case study: Oec Digital Transformation'
+  description: Case-study graphic for the Ct Oec Transformation project (Oec Digital
+    Transformation).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-website-redesign-oec-website-redesign-alt
+  path: ct_oec_website_redesign/oec-website-redesign-alt.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-website-redesign
+  alt: 'Ct Oec Website Redesign case study: Oec Website Redesign Alt'
+  description: Case-study graphic for the Ct Oec Website Redesign project (Oec Website
+    Redesign Alt).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-website-redesign-oec-website-redesign-alt-2
+  path: ct_oec_website_redesign/oec-website-redesign-alt.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-website-redesign
+  alt: 'Ct Oec Website Redesign case study: Oec Website Redesign Alt'
+  description: Case-study graphic for the Ct Oec Website Redesign project (Oec Website
+    Redesign Alt).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-website-redesign-oec-website-redesign
+  path: ct_oec_website_redesign/oec-website-redesign.gif
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-website-redesign
+  alt: 'Ct Oec Website Redesign case study: Oec Website Redesign'
+  description: Case-study graphic for the Ct Oec Website Redesign project (Oec Website
+    Redesign).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-website-redesign-oec-website-redesign-2
+  path: ct_oec_website_redesign/oec-website-redesign.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-website-redesign
+  alt: 'Ct Oec Website Redesign case study: Oec Website Redesign'
+  description: Case-study graphic for the Ct Oec Website Redesign project (Oec Website
+    Redesign).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ct-oec-website-redesign-oec-website-redesign-3
+  path: ct_oec_website_redesign/oec-website-redesign.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ct-oec-website-redesign
+  alt: 'Ct Oec Website Redesign case study: Oec Website Redesign'
+  description: Case-study graphic for the Ct Oec Website Redesign project (Oec Website
+    Redesign).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ctgov-analytics-gov-analytics
+  path: ctgov_analytics/gov-analytics.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ctgov-analytics
+  alt: 'Ctgov Analytics case study: Gov Analytics'
+  description: Case-study graphic for the Ctgov Analytics project (Gov Analytics).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ctgov-analytics-gov-analytics-2
+  path: ctgov_analytics/gov-analytics.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ctgov-analytics
+  alt: 'Ctgov Analytics case study: Gov Analytics'
+  description: Case-study graphic for the Ctgov Analytics project (Gov Analytics).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-digital-acquisition-accelerator-digital-acquisition-accelerator
+  path: digital_acquisition_accelerator/digital-acquisition-accelerator.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - digital-acquisition-accelerator
+  alt: 'Digital Acquisition Accelerator case study: Digital Acquisition Accelerator'
+  description: Case-study graphic for the Digital Acquisition Accelerator project
+    (Digital Acquisition Accelerator).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-digital-acquisition-accelerator-digital-acquisition-accelerator-2
+  path: digital_acquisition_accelerator/digital-acquisition-accelerator.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - digital-acquisition-accelerator
+  alt: 'Digital Acquisition Accelerator case study: Digital Acquisition Accelerator'
+  description: Case-study graphic for the Digital Acquisition Accelerator project
+    (Digital Acquisition Accelerator).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-digital-transformation-framework-digital-government-transformation
+  path: digital_transformation_framework/digital-government-transformation.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - digital-transformation-framework
+  alt: 'Digital Transformation Framework case study: Digital Government Transformation'
+  description: Case-study graphic for the Digital Transformation Framework project
+    (Digital Government Transformation).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-digital-transformation-framework-digital-government-transformation-2
+  path: digital_transformation_framework/digital-government-transformation.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - digital-transformation-framework
+  alt: 'Digital Transformation Framework case study: Digital Government Transformation'
+  description: Case-study graphic for the Digital Transformation Framework project
+    (Digital Government Transformation).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-dol-legacy-system-modernization-legacy-system-modernization
+  path: dol_legacy_system_modernization/legacy-system-modernization.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - dol-legacy-system-modernization
+  alt: 'Dol Legacy System Modernization case study: Legacy System Modernization'
+  description: Case-study graphic for the Dol Legacy System Modernization project
+    (Legacy System Modernization).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-dol-legacy-system-modernization-legacy-system-modernization-2
+  path: dol_legacy_system_modernization/legacy-system-modernization.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - dol-legacy-system-modernization
+  alt: 'Dol Legacy System Modernization case study: Legacy System Modernization'
+  description: Case-study graphic for the Dol Legacy System Modernization project
+    (Legacy System Modernization).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-epa-sdwis-advice-epa-sdwis-advice
+  path: epa_sdwis_advice/epa-sdwis-advice.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - epa-sdwis-advice
+  alt: 'Epa Sdwis Advice case study: Epa Sdwis Advice'
+  description: Case-study graphic for the Epa Sdwis Advice project (Epa Sdwis Advice).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-epa-sdwis-advice-epa-sdwis-advice-2
+  path: epa_sdwis_advice/epa-sdwis-advice.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - epa-sdwis-advice
+  alt: 'Epa Sdwis Advice case study: Epa Sdwis Advice'
+  description: Case-study graphic for the Epa Sdwis Advice project (Epa Sdwis Advice).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-goc-nextgen-hr-pay-system-nextgen-hr-system
+  path: goc_nextgen_hr_pay_system/nextgen-hr-system.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - goc-nextgen-hr-pay-system
+  alt: 'Goc Nextgen Hr Pay System case study: Nextgen Hr System'
+  description: Case-study graphic for the Goc Nextgen Hr Pay System project (Nextgen
+    Hr System).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-goc-nextgen-hr-pay-system-nextgen-hr-system-2
+  path: goc_nextgen_hr_pay_system/nextgen-hr-system.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - goc-nextgen-hr-pay-system
+  alt: 'Goc Nextgen Hr Pay System case study: Nextgen Hr System'
+  description: Case-study graphic for the Goc Nextgen Hr Pay System project (Nextgen
+    Hr System).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-hhs-telehealth-website-telehealth-alt-01
+  path: hhs_telehealth_website/telehealth-alt-01.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - hhs-telehealth-website
+  alt: 'Hhs Telehealth Website case study: Telehealth Alt 01'
+  description: Case-study graphic for the Hhs Telehealth Website project (Telehealth
+    Alt 01).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-hhs-telehealth-website-telehealth-alt-01-2
+  path: hhs_telehealth_website/telehealth-alt-01.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - hhs-telehealth-website
+  alt: 'Hhs Telehealth Website case study: Telehealth Alt 01'
+  description: Case-study graphic for the Hhs Telehealth Website project (Telehealth
+    Alt 01).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-hhs-telehealth-website-telehealth-alt-02
+  path: hhs_telehealth_website/telehealth-alt-02.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - hhs-telehealth-website
+  alt: 'Hhs Telehealth Website case study: Telehealth Alt 02'
+  description: Case-study graphic for the Hhs Telehealth Website project (Telehealth
+    Alt 02).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-hhs-telehealth-website-telehealth-alt-02-2
+  path: hhs_telehealth_website/telehealth-alt-02.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - hhs-telehealth-website
+  alt: 'Hhs Telehealth Website case study: Telehealth Alt 02'
+  description: Case-study graphic for the Hhs Telehealth Website project (Telehealth
+    Alt 02).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-hhs-telehealth-website-telehealth
+  path: hhs_telehealth_website/telehealth.gif
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - hhs-telehealth-website
+  alt: 'Hhs Telehealth Website case study: Telehealth'
+  description: Case-study graphic for the Hhs Telehealth Website project (Telehealth).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-hhs-telehealth-website-telehealth-2
+  path: hhs_telehealth_website/telehealth.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - hhs-telehealth-website
+  alt: 'Hhs Telehealth Website case study: Telehealth'
+  description: Case-study graphic for the Hhs Telehealth Website project (Telehealth).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-hhs-telehealth-website-telehealth-3
+  path: hhs_telehealth_website/telehealth.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - hhs-telehealth-website
+  alt: 'Hhs Telehealth Website case study: Telehealth'
+  description: Case-study graphic for the Hhs Telehealth Website project (Telehealth).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-jabil-iot-industrial-iot
+  path: jabil_iot/industrial-iot.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - jabil-iot
+  alt: 'Jabil Iot case study: Industrial Iot'
+  description: Case-study graphic for the Jabil Iot project (Industrial Iot).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-jabil-iot-industrial-iot-2
+  path: jabil_iot/industrial-iot.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - jabil-iot
+  alt: 'Jabil Iot case study: Industrial Iot'
+  description: Case-study graphic for the Jabil Iot project (Industrial Iot).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-jil-website-redesign-jil-website-redesign
+  path: jil_website_redesign/jil-website-redesign.gif
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - jil-website-redesign
+  alt: 'Jil Website Redesign case study: Jil Website Redesign'
+  description: Case-study graphic for the Jil Website Redesign project (Jil Website
+    Redesign).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-jil-website-redesign-jil-website-redesign-2
+  path: jil_website_redesign/jil-website-redesign.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - jil-website-redesign
+  alt: 'Jil Website Redesign case study: Jil Website Redesign'
+  description: Case-study graphic for the Jil Website Redesign project (Jil Website
+    Redesign).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-jil-website-redesign-jil-website-redesign-3
+  path: jil_website_redesign/jil-website-redesign.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - jil-website-redesign
+  alt: 'Jil Website Redesign case study: Jil Website Redesign'
+  description: Case-study graphic for the Jil Website Redesign project (Jil Website
+    Redesign).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ncoc-refugee-admissions-research-refugee-admission-journey-map
+  path: ncoc_refugee_admissions_research/refugee-admission-journey-map.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ncoc-refugee-admissions-research
+  alt: 'Ncoc Refugee Admissions Research case study: Refugee Admission Journey Map'
+  description: Case-study graphic for the Ncoc Refugee Admissions Research project
+    (Refugee Admission Journey Map).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ncoc-refugee-admissions-research-refugee-admission-journey-map-2
+  path: ncoc_refugee_admissions_research/refugee-admission-journey-map.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ncoc-refugee-admissions-research
+  alt: 'Ncoc Refugee Admissions Research case study: Refugee Admission Journey Map'
+  description: Case-study graphic for the Ncoc Refugee Admissions Research project
+    (Refugee Admission Journey Map).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ncoc-refugee-admissions-research-refugee-admissions
+  path: ncoc_refugee_admissions_research/refugee-admissions.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ncoc-refugee-admissions-research
+  alt: 'Ncoc Refugee Admissions Research case study: Refugee Admissions'
+  description: Case-study graphic for the Ncoc Refugee Admissions Research project
+    (Refugee Admissions).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ncoc-refugee-admissions-research-refugee-admissions-2
+  path: ncoc_refugee_admissions_research/refugee-admissions.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ncoc-refugee-admissions-research
+  alt: 'Ncoc Refugee Admissions Research case study: Refugee Admissions'
+  description: Case-study graphic for the Ncoc Refugee Admissions Research project
+    (Refugee Admissions).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-sba-ascent-sba-ascent
+  path: sba_ascent/sba-ascent.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - sba-ascent
+  alt: 'Sba Ascent case study: Sba Ascent'
+  description: Case-study graphic for the Sba Ascent project (Sba Ascent).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-sba-ascent-sba-ascent-2
+  path: sba_ascent/sba-ascent.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - sba-ascent
+  alt: 'Sba Ascent case study: Sba Ascent'
+  description: Case-study graphic for the Sba Ascent project (Sba Ascent).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ssa-agile-microsprints-agile-board
+  path: ssa_agile_microsprints/agile-board.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ssa-agile-microsprints
+  alt: 'Ssa Agile Microsprints case study: Agile Board'
+  description: Case-study graphic for the Ssa Agile Microsprints project (Agile Board).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ssa-agile-microsprints-agile-board-2
+  path: ssa_agile_microsprints/agile-board.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ssa-agile-microsprints
+  alt: 'Ssa Agile Microsprints case study: Agile Board'
+  description: Case-study graphic for the Ssa Agile Microsprints project (Agile Board).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-talkto-talkto-demo-page
+  path: talkto/talkto-demo-page.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - talkto
+  alt: 'Talkto case study: Talkto Demo Page'
+  description: Case-study graphic for the Talkto project (Talkto Demo Page).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-talkto-talkto
+  path: talkto/talkto.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - talkto
+  alt: 'Talkto case study: Talkto'
+  description: Case-study graphic for the Talkto project (Talkto).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-talkto-talkto-2
+  path: talkto/talkto.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - talkto
+  alt: 'Talkto case study: Talkto'
+  description: Case-study graphic for the Talkto project (Talkto).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-tsa-cloud-adoption-cloud-jumpstarter
+  path: tsa_cloud_adoption/cloud-jumpstarter.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - tsa-cloud-adoption
+  alt: 'Tsa Cloud Adoption case study: Cloud Jumpstarter'
+  description: Case-study graphic for the Tsa Cloud Adoption project (Cloud Jumpstarter).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-tsa-cloud-adoption-cloud-jumpstarter-2
+  path: tsa_cloud_adoption/cloud-jumpstarter.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - tsa-cloud-adoption
+  alt: 'Tsa Cloud Adoption case study: Cloud Jumpstarter'
+  description: Case-study graphic for the Tsa Cloud Adoption project (Cloud Jumpstarter).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-united-nations-accessibility-accessibility
+  path: united_nations_accessibility/accessibility.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - united-nations-accessibility
+  alt: 'United Nations Accessibility case study: Accessibility'
+  description: Case-study graphic for the United Nations Accessibility project (Accessibility).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-united-nations-accessibility-accessibility-2
+  path: united_nations_accessibility/accessibility.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - united-nations-accessibility
+  alt: 'United Nations Accessibility case study: Accessibility'
+  description: Case-study graphic for the United Nations Accessibility project (Accessibility).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-us-navy-protosketching-protosketching
+  path: us_navy_protosketching/protosketching.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - us-navy-protosketching
+  alt: 'Us Navy Protosketching case study: Protosketching'
+  description: Case-study graphic for the Us Navy Protosketching project (Protosketching).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-us-navy-protosketching-protosketching-2
+  path: us_navy_protosketching/protosketching.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - us-navy-protosketching
+  alt: 'Us Navy Protosketching case study: Protosketching'
+  description: Case-study graphic for the Us Navy Protosketching project (Protosketching).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-affms-air-force-fitness-management-system
+  path: usaf_affms/air-force-fitness-management-system.gif
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-affms
+  alt: 'Usaf Affms case study: Air Force Fitness Management System'
+  description: Case-study graphic for the Usaf Affms project (Air Force Fitness Management
+    System).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-affms-air-force-fitness-management-system-2
+  path: usaf_affms/air-force-fitness-management-system.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-affms
+  alt: 'Usaf Affms case study: Air Force Fitness Management System'
+  description: Case-study graphic for the Usaf Affms project (Air Force Fitness Management
+    System).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-affms-air-force-fitness-management-system-3
+  path: usaf_affms/air-force-fitness-management-system.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-affms
+  alt: 'Usaf Affms case study: Air Force Fitness Management System'
+  description: Case-study graphic for the Usaf Affms project (Air Force Fitness Management
+    System).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-amp-amp
+  path: usaf_amp/amp.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-amp
+  alt: 'Usaf Amp case study: Amp'
+  description: Case-study graphic for the Usaf Amp project (Amp).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-amp-amp-2
+  path: usaf_amp/amp.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-amp
+  alt: 'Usaf Amp case study: Amp'
+  description: Case-study graphic for the Usaf Amp project (Amp).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-arms-arms
+  path: usaf_arms/arms.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-arms
+  alt: 'Usaf Arms case study: Arms'
+  description: Case-study graphic for the Usaf Arms project (Arms).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-arms-arms-2
+  path: usaf_arms/arms.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-arms
+  alt: 'Usaf Arms case study: Arms'
+  description: Case-study graphic for the Usaf Arms project (Arms).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-bespin-design-studio-bespin-design-studio
+  path: usaf_bespin_design_studio/bespin-design-studio.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-bespin-design-studio
+  alt: 'Usaf Bespin Design Studio case study: Bespin Design Studio'
+  description: Case-study graphic for the Usaf Bespin Design Studio project (Bespin
+    Design Studio).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-bespin-design-studio-bespin-design-studio-2
+  path: usaf_bespin_design_studio/bespin-design-studio.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-bespin-design-studio
+  alt: 'Usaf Bespin Design Studio case study: Bespin Design Studio'
+  description: Case-study graphic for the Usaf Bespin Design Studio project (Bespin
+    Design Studio).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-bespin-design-system-bespin-design-system
+  path: usaf_bespin_design_system/bespin-design-system.gif
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-bespin-design-system
+  alt: 'Usaf Bespin Design System case study: Bespin Design System'
+  description: Case-study graphic for the Usaf Bespin Design System project (Bespin
+    Design System).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-bespin-design-system-design-system-alt
+  path: usaf_bespin_design_system/design-system-alt.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-bespin-design-system
+  alt: 'Usaf Bespin Design System case study: Design System Alt'
+  description: Case-study graphic for the Usaf Bespin Design System project (Design
+    System Alt).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-bespin-design-system-design-system-alt-2
+  path: usaf_bespin_design_system/design-system-alt.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-bespin-design-system
+  alt: 'Usaf Bespin Design System case study: Design System Alt'
+  description: Case-study graphic for the Usaf Bespin Design System project (Design
+    System Alt).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-bespin-design-system-design-system
+  path: usaf_bespin_design_system/design-system.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-bespin-design-system
+  alt: 'Usaf Bespin Design System case study: Design System'
+  description: Case-study graphic for the Usaf Bespin Design System project (Design
+    System).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-bespin-design-system-design-system-2
+  path: usaf_bespin_design_system/design-system.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-bespin-design-system
+  alt: 'Usaf Bespin Design System case study: Design System'
+  description: Case-study graphic for the Usaf Bespin Design System project (Design
+    System).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-bespin-design-system-project-design-system
+  path: usaf_bespin_design_system/project-design-system.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-bespin-design-system
+  alt: 'Usaf Bespin Design System case study: Project Design System'
+  description: Case-study graphic for the Usaf Bespin Design System project (Project
+    Design System).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-bespin-design-system-project-design-system-2
+  path: usaf_bespin_design_system/project-design-system.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: diagram
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-bespin-design-system
+  alt: 'Usaf Bespin Design System case study: Project Design System'
+  description: Case-study graphic for the Usaf Bespin Design System project (Project
+    Design System).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-bespin-enablement-bespin-airmen-enablement
+  path: usaf_bespin_enablement/bespin-airmen-enablement.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-bespin-enablement
+  alt: 'Usaf Bespin Enablement case study: Bespin Airmen Enablement'
+  description: Case-study graphic for the Usaf Bespin Enablement project (Bespin Airmen
+    Enablement).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-bespin-enablement-bespin-airmen-enablement-2
+  path: usaf_bespin_enablement/bespin-airmen-enablement.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-bespin-enablement
+  alt: 'Usaf Bespin Enablement case study: Bespin Airmen Enablement'
+  description: Case-study graphic for the Usaf Bespin Enablement project (Bespin Airmen
+    Enablement).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-bespin-transformation-support-bespin-transformation-support
+  path: usaf_bespin_transformation_support/bespin-transformation-support.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-bespin-transformation-support
+  alt: 'Usaf Bespin Transformation Support case study: Bespin Transformation Support'
+  description: Case-study graphic for the Usaf Bespin Transformation Support project
+    (Bespin Transformation Support).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-bespin-transformation-support-bespin-transformation-support-2
+  path: usaf_bespin_transformation_support/bespin-transformation-support.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-bespin-transformation-support
+  alt: 'Usaf Bespin Transformation Support case study: Bespin Transformation Support'
+  description: Case-study graphic for the Usaf Bespin Transformation Support project
+    (Bespin Transformation Support).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-gearfit-gearfit-alt
+  path: usaf_gearfit/gearfit-alt.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-gearfit
+  alt: 'Usaf Gearfit case study: Gearfit Alt'
+  description: Case-study graphic for the Usaf Gearfit project (Gearfit Alt).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-gearfit-gearfit-alt-2
+  path: usaf_gearfit/gearfit-alt.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-gearfit
+  alt: 'Usaf Gearfit case study: Gearfit Alt'
+  description: Case-study graphic for the Usaf Gearfit project (Gearfit Alt).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-gearfit-gearfit
+  path: usaf_gearfit/gearfit.gif
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-gearfit
+  alt: 'Usaf Gearfit case study: Gearfit'
+  description: Case-study graphic for the Usaf Gearfit project (Gearfit).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-gearfit-gearfit-2
+  path: usaf_gearfit/gearfit.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-gearfit
+  alt: 'Usaf Gearfit case study: Gearfit'
+  description: Case-study graphic for the Usaf Gearfit project (Gearfit).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-gearfit-gearfit-3
+  path: usaf_gearfit/gearfit.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-gearfit
+  alt: 'Usaf Gearfit case study: Gearfit'
+  description: Case-study graphic for the Usaf Gearfit project (Gearfit).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-jocas-jocas-alt
+  path: usaf_jocas/jocas-alt.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-jocas
+  alt: 'Usaf Jocas case study: Jocas Alt'
+  description: Case-study graphic for the Usaf Jocas project (Jocas Alt).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-jocas-jocas-alt-2
+  path: usaf_jocas/jocas-alt.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-jocas
+  alt: 'Usaf Jocas case study: Jocas Alt'
+  description: Case-study graphic for the Usaf Jocas project (Jocas Alt).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-jocas-jocas
+  path: usaf_jocas/jocas.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-jocas
+  alt: 'Usaf Jocas case study: Jocas'
+  description: Case-study graphic for the Usaf Jocas project (Jocas).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-jocas-jocas-2
+  path: usaf_jocas/jocas.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-jocas
+  alt: 'Usaf Jocas case study: Jocas'
+  description: Case-study graphic for the Usaf Jocas project (Jocas).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-logux-logux
+  path: usaf_logux/logux.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-logux
+  alt: 'Usaf Logux case study: Logux'
+  description: Case-study graphic for the Usaf Logux project (Logux).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-logux-logux-2
+  path: usaf_logux/logux.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-logux
+  alt: 'Usaf Logux case study: Logux'
+  description: Case-study graphic for the Usaf Logux project (Logux).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-mask-mask-alt
+  path: usaf_mask/mask-alt.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-mask
+  alt: 'Usaf Mask case study: Mask Alt'
+  description: Case-study graphic for the Usaf Mask project (Mask Alt).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-mask-mask-alt-2
+  path: usaf_mask/mask-alt.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-mask
+  alt: 'Usaf Mask case study: Mask Alt'
+  description: Case-study graphic for the Usaf Mask project (Mask Alt).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-mask-mask
+  path: usaf_mask/mask.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-mask
+  alt: 'Usaf Mask case study: Mask'
+  description: Case-study graphic for the Usaf Mask project (Mask).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-mask-mask-2
+  path: usaf_mask/mask.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-mask
+  alt: 'Usaf Mask case study: Mask'
+  description: Case-study graphic for the Usaf Mask project (Mask).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-sda-service-design
+  path: usaf_sda/service-design.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-sda
+  alt: 'Usaf Sda case study: Service Design'
+  description: Case-study graphic for the Usaf Sda project (Service Design).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-sda-service-design-2
+  path: usaf_sda/service-design.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-sda
+  alt: 'Usaf Sda case study: Service Design'
+  description: Case-study graphic for the Usaf Sda project (Service Design).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-wxpo-bifrost-wxpo-bifrost
+  path: usaf_wxpo_bifrost/wxpo-bifrost.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-wxpo-bifrost
+  alt: 'Usaf Wxpo Bifrost case study: Wxpo Bifrost'
+  description: Case-study graphic for the Usaf Wxpo Bifrost project (Wxpo Bifrost).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-wxpo-bifrost-wxpo-bifrost-2
+  path: usaf_wxpo_bifrost/wxpo-bifrost.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-wxpo-bifrost
+  alt: 'Usaf Wxpo Bifrost case study: Wxpo Bifrost'
+  description: Case-study graphic for the Usaf Wxpo Bifrost project (Wxpo Bifrost).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-wxpo-cloud-migration-wxpo-cloud-migration
+  path: usaf_wxpo_cloud_migration/wxpo-cloud-migration.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-wxpo-cloud-migration
+  alt: 'Usaf Wxpo Cloud Migration case study: Wxpo Cloud Migration'
+  description: Case-study graphic for the Usaf Wxpo Cloud Migration project (Wxpo
+    Cloud Migration).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-wxpo-cloud-migration-wxpo-cloud-migration-2
+  path: usaf_wxpo_cloud_migration/wxpo-cloud-migration.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-wxpo-cloud-migration
+  alt: 'Usaf Wxpo Cloud Migration case study: Wxpo Cloud Migration'
+  description: Case-study graphic for the Usaf Wxpo Cloud Migration project (Wxpo
+    Cloud Migration).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-wxpo-data-catalog-wxpo-weather-data-catalog
+  path: usaf_wxpo_data_catalog/wxpo-weather-data-catalog.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-wxpo-data-catalog
+  alt: 'Usaf Wxpo Data Catalog case study: Wxpo Weather Data Catalog'
+  description: Case-study graphic for the Usaf Wxpo Data Catalog project (Wxpo Weather
+    Data Catalog).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-wxpo-data-catalog-wxpo-weather-data-catalog-2
+  path: usaf_wxpo_data_catalog/wxpo-weather-data-catalog.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-wxpo-data-catalog
+  alt: 'Usaf Wxpo Data Catalog case study: Wxpo Weather Data Catalog'
+  description: Case-study graphic for the Usaf Wxpo Data Catalog project (Wxpo Weather
+    Data Catalog).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-wxpo-warpspeed-wxpo-warpspeed
+  path: usaf_wxpo_warpspeed/wxpo-warpspeed.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-wxpo-warpspeed
+  alt: 'Usaf Wxpo Warpspeed case study: Wxpo Warpspeed'
+  description: Case-study graphic for the Usaf Wxpo Warpspeed project (Wxpo Warpspeed).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usaf-wxpo-warpspeed-wxpo-warpspeed-2
+  path: usaf_wxpo_warpspeed/wxpo-warpspeed.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usaf-wxpo-warpspeed
+  alt: 'Usaf Wxpo Warpspeed case study: Wxpo Warpspeed'
+  description: Case-study graphic for the Usaf Wxpo Warpspeed project (Wxpo Warpspeed).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-uscis-everify-modernization-employment-eligibility-verification-alt-01
+  path: uscis_everify_modernization/employment-eligibility-verification-alt-01.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - uscis-everify-modernization
+  alt: 'Uscis Everify Modernization case study: Employment Eligibility Verification
+    Alt 01'
+  description: Case-study graphic for the Uscis Everify Modernization project (Employment
+    Eligibility Verification Alt 01).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-uscis-everify-modernization-employment-eligibility-verification-alt-01-2
+  path: uscis_everify_modernization/employment-eligibility-verification-alt-01.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - uscis-everify-modernization
+  alt: 'Uscis Everify Modernization case study: Employment Eligibility Verification
+    Alt 01'
+  description: Case-study graphic for the Uscis Everify Modernization project (Employment
+    Eligibility Verification Alt 01).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-uscis-everify-modernization-employment-eligibility-verification-alt-02
+  path: uscis_everify_modernization/employment-eligibility-verification-alt-02.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - uscis-everify-modernization
+  alt: 'Uscis Everify Modernization case study: Employment Eligibility Verification
+    Alt 02'
+  description: Case-study graphic for the Uscis Everify Modernization project (Employment
+    Eligibility Verification Alt 02).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-uscis-everify-modernization-employment-eligibility-verification-alt-02-2
+  path: uscis_everify_modernization/employment-eligibility-verification-alt-02.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - uscis-everify-modernization
+  alt: 'Uscis Everify Modernization case study: Employment Eligibility Verification
+    Alt 02'
+  description: Case-study graphic for the Uscis Everify Modernization project (Employment
+    Eligibility Verification Alt 02).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-uscis-everify-modernization-employment-eligibility-verification
+  path: uscis_everify_modernization/employment-eligibility-verification.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - uscis-everify-modernization
+  alt: 'Uscis Everify Modernization case study: Employment Eligibility Verification'
+  description: Case-study graphic for the Uscis Everify Modernization project (Employment
+    Eligibility Verification).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-uscis-everify-modernization-employment-eligibility-verification-2
+  path: uscis_everify_modernization/employment-eligibility-verification.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - uscis-everify-modernization
+  alt: 'Uscis Everify Modernization case study: Employment Eligibility Verification'
+  description: Case-study graphic for the Uscis Everify Modernization project (Employment
+    Eligibility Verification).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usda-recreation-information-database-api-recreation-api
+  path: usda_recreation_information_database_api/recreation-api.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usda-recreation-information-database-api
+  alt: 'Usda Recreation Information Database Api case study: Recreation Api'
+  description: Case-study graphic for the Usda Recreation Information Database Api
+    project (Recreation Api).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-usda-recreation-information-database-api-recreation-api-2
+  path: usda_recreation_information_database_api/recreation-api.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - usda-recreation-information-database-api
+  alt: 'Usda Recreation Information Database Api case study: Recreation Api'
+  description: Case-study graphic for the Usda Recreation Information Database Api
+    project (Recreation Api).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ussf-web-portal-ussf-web-portal
+  path: ussf_web_portal/ussf-web-portal.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ussf-web-portal
+  alt: 'Ussf Web Portal case study: Ussf Web Portal'
+  description: Case-study graphic for the Ussf Web Portal project (Ussf Web Portal).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-ussf-web-portal-ussf-web-portal-2
+  path: ussf_web_portal/ussf-web-portal.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - ussf-web-portal
+  alt: 'Ussf Web Portal case study: Ussf Web Portal'
+  description: Case-study graphic for the Ussf Web Portal project (Ussf Web Portal).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-va-api-developer-outreach-api-developer-outreach
+  path: va_api_developer_outreach/api-developer-outreach.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - va-api-developer-outreach
+  alt: 'Va Api Developer Outreach case study: Api Developer Outreach'
+  description: Case-study graphic for the Va Api Developer Outreach project (Api Developer
+    Outreach).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-va-api-developer-outreach-api-developer-outreach-2
+  path: va_api_developer_outreach/api-developer-outreach.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - va-api-developer-outreach
+  alt: 'Va Api Developer Outreach case study: Api Developer Outreach'
+  description: Case-study graphic for the Va Api Developer Outreach project (Api Developer
+    Outreach).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-va-api-governance-research-api-governance
+  path: va_api_governance_research/api-governance.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - va-api-governance-research
+  alt: 'Va Api Governance Research case study: Api Governance'
+  description: Case-study graphic for the Va Api Governance Research project (Api
+    Governance).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-va-api-governance-research-api-governance-2
+  path: va_api_governance_research/api-governance.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - va-api-governance-research
+  alt: 'Va Api Governance Research case study: Api Governance'
+  description: Case-study graphic for the Va Api Governance Research project (Api
+    Governance).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-va-api-landscape-analysis-api-machine
+  path: va_api_landscape_analysis/api-machine.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - va-api-landscape-analysis
+  alt: 'Va Api Landscape Analysis case study: Api Machine'
+  description: Case-study graphic for the Va Api Landscape Analysis project (Api Machine).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-va-api-landscape-analysis-api-machine-2
+  path: va_api_landscape_analysis/api-machine.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - va-api-landscape-analysis
+  alt: 'Va Api Landscape Analysis case study: Api Machine'
+  description: Case-study graphic for the Va Api Landscape Analysis project (Api Machine).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-va-api-scorecard-mvp-api-scorecard-screenshot
+  path: va_api_scorecard_mvp/api-scorecard-screenshot.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - va-api-scorecard-mvp
+  alt: 'Va Api Scorecard Mvp case study: Api Scorecard Screenshot'
+  description: Case-study graphic for the Va Api Scorecard Mvp project (Api Scorecard
+    Screenshot).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-va-api-scorecard-mvp-api-scorecard
+  path: va_api_scorecard_mvp/api-scorecard.gif
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - va-api-scorecard-mvp
+  alt: 'Va Api Scorecard Mvp case study: Api Scorecard'
+  description: Case-study graphic for the Va Api Scorecard Mvp project (Api Scorecard).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-va-api-scorecard-mvp-api-scorecard-2
+  path: va_api_scorecard_mvp/api-scorecard.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - va-api-scorecard-mvp
+  alt: 'Va Api Scorecard Mvp case study: Api Scorecard'
+  description: Case-study graphic for the Va Api Scorecard Mvp project (Api Scorecard).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-va-api-scorecard-mvp-api-scorecard-3
+  path: va_api_scorecard_mvp/api-scorecard.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - va-api-scorecard-mvp
+  alt: 'Va Api Scorecard Mvp case study: Api Scorecard'
+  description: Case-study graphic for the Va Api Scorecard Mvp project (Api Scorecard).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-va-diffusion-marketplace-diffusion-marketplace
+  path: va_diffusion_marketplace/diffusion-marketplace.gif
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - va-diffusion-marketplace
+  alt: 'Va Diffusion Marketplace case study: Diffusion Marketplace'
+  description: Case-study graphic for the Va Diffusion Marketplace project (Diffusion
+    Marketplace).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-va-diffusion-marketplace-diffusion-marketplace-2
+  path: va_diffusion_marketplace/diffusion-marketplace.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - va-diffusion-marketplace
+  alt: 'Va Diffusion Marketplace case study: Diffusion Marketplace'
+  description: Case-study graphic for the Va Diffusion Marketplace project (Diffusion
+    Marketplace).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-va-diffusion-marketplace-diffusion-marketplace-3
+  path: va_diffusion_marketplace/diffusion-marketplace.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - va-diffusion-marketplace
+  alt: 'Va Diffusion Marketplace case study: Diffusion Marketplace'
+  description: Case-study graphic for the Va Diffusion Marketplace project (Diffusion
+    Marketplace).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-va-mobile-product-strategy-va-flagship-mobile-app
+  path: va_mobile_product_strategy/va-flagship-mobile-app.png
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - va-mobile-product-strategy
+  alt: 'Va Mobile Product Strategy case study: Va Flagship Mobile App'
+  description: Case-study graphic for the Va Mobile Product Strategy project (Va Flagship
+    Mobile App).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false
+- id: project-va-mobile-product-strategy-va-flagship-mobile-app-2
+  path: va_mobile_product_strategy/va-flagship-mobile-app.svg
+  repo: skylight.digital
+  date: '2026-03-26'
+  type: illustration
+  themes:
+  - case-study
+  tags: []
+  used_in:
+  - va-mobile-product-strategy
+  alt: 'Va Mobile Product Strategy case study: Va Flagship Mobile App'
+  description: Case-study graphic for the Va Mobile Product Strategy project (Va Flagship
+    Mobile App).
+  permissions: skylight-owned
+  classification: public
+  archived: false
+  pending_classification: false


### PR DESCRIPTION
**Phase C.2** of the federation asset registry — catalogs the rest of skylight.digital's source images via **path-derived enrichment** (no risky guessing). Builds on C.1 (img/brand).

## What's in it (741 new entries, 3 manifests)
- **`img/people`** (411) — team headshots. `people: [name-slug]` derived from the `firstname-lastname` filenames; `type: headshot`, `theme: team`.
- **`img/projects`** (180) — case-study graphics. `used_in: [project-slug]` from the per-project directories (`cdc_dibbs`, `usaf_affms`, `18f_consulting`, …); `theme: case-study`.
- **`img/blog`** (150) — post graphics. `used_in: [post-slug]` from the per-post directories.

All uniform `permissions: skylight-owned` / `classification: public` (they're on the public site). Plus a one-line **C.1 nit fix** (the doubled "Illustration Illustration Types" alt).

## ✅ Verified
- All 4 skylight.digital manifests validate **0 errors / 0 warnings**.
- Cross-repo aggregation (hub + skylight.digital) = **865 assets, 0 id collisions**.

## 👀 Review notes — judgment fields I deliberately left for the team
- **People currency:** every headshot is cataloged as active. Some are likely **former** Skylighters whose entries should be `archived: true` (`archived_reason: person-no-longer-at-skylight`). One oddball: `abraham-lincoln.png` (not a Skylighter).
- **Client/mission tags:** I set `used_in: [project-slug]` but **skipped `tags`** — mapping each project to controlled client tags (`cdc`, `usaf`, …) is your call.
- **gif type:** the ~11 `.gif` files are typed `illustration`, not `gif`.

Open for your review — not auto-merged, since it's a large catalog of named individuals + project associations worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)