### PR TITLE
ci: mint hub access via the federation GitHub App (retire HUB_READ_TOKEN)

### DIFF
--- a/.github/workflows/case-study-lint.yml
+++ b/.github/workflows/case-study-lint.yml
@@ -8,18 +8,16 @@ name: case-study-lint
 #
 # The linter is federation canon and lives in skylight-hub (a PRIVATE repo).
 # This public repo can't read it with the default GITHUB_TOKEN, so the gate
-# checks out the hub linter using a HUB_READ_TOKEN secret (a fine-grained PAT
-# with read access to skylight-hq/skylight-hub, contents:read).
+# checks out the hub linter using a short-lived token minted from the
+# federation GitHub App (Contents:Read, scoped to skylight-hub, ~1h TTL) —
+# the org-owned, ephemeral mechanism the whole federation shares. No
+# long-lived PAT.
 #
 #   *** ACTIVATION ***
-#   Until HUB_READ_TOKEN is added to this repo's Actions secrets, the gate
-#   SKIPS with a warning (so this workflow merges cleanly and self-activates).
-#   To activate: create a fine-grained PAT (read-only, contents, on
-#   skylight-hq/skylight-hub) and add it as the HUB_READ_TOKEN repo secret.
-#
-# Once the federation resolves hub access (e.g., hub goes public, or a shared
-# org token lands), this workflow needs no change — it already prefers the
-# secret and falls back to skipping.
+#   The gate self-activates when the App is configured for this repo: the
+#   FEDERATION_APP_ID variable + FEDERATION_APP_PRIVATE_KEY secret, with the
+#   App installed on skylight-hq/skylight-hub. Until then the token step is
+#   skipped and the gate SKIPS with a warning, so this workflow merges cleanly.
 
 on:
   pull_request:
@@ -48,10 +46,23 @@ jobs:
       - name: Checkout skylight.digital
         uses: actions/checkout@v4
 
+      # Mint a short-lived token from the federation GitHub App to read the
+      # canonical linter out of the private skylight-hub repo. Guarded so the
+      # gate self-skips until the App is configured.
+      - name: Mint hub-read App token
+        id: app-token
+        if: ${{ vars.FEDERATION_APP_ID != '' }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.FEDERATION_APP_ID }}
+          private-key: ${{ secrets.FEDERATION_APP_PRIVATE_KEY }}
+          owner: skylight-hq
+          repositories: skylight-hub
+
       - name: Detect hub-access token
         id: cfg
         env:
-          HUB_TOKEN: ${{ secrets.HUB_READ_TOKEN }}
+          HUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if [ -n "$HUB_TOKEN" ]; then
             echo "ok=true" >> "$GITHUB_OUTPUT"
@@ -62,10 +73,10 @@ jobs:
       - name: Gate inactive notice
         if: steps.cfg.outputs.ok != 'true'
         run: |
-          echo "::warning title=case-study-lint inactive::No HUB_READ_TOKEN secret found. " \
-               "The case-study taxonomy gate is not enforcing. Add a fine-grained PAT " \
-               "(read-only, contents, on skylight-hq/skylight-hub) as the HUB_READ_TOKEN " \
-               "repo secret to activate. Skipping for now (non-blocking)."
+          echo "::warning title=case-study-lint inactive::Federation GitHub App not configured " \
+               "(needs the FEDERATION_APP_ID variable + FEDERATION_APP_PRIVATE_KEY secret, with the " \
+               "App installed on skylight-hq/skylight-hub). The case-study taxonomy gate is not " \
+               "enforcing. Skipping for now (non-blocking)."
           echo "Gate skipped — see warning above."
 
       - name: Checkout skylight-hub linter (canon)
@@ -73,7 +84,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: skylight-hq/skylight-hub
-          token: ${{ secrets.HUB_READ_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: .hub
           sparse-checkout: |
             plugins/skylight-website-case-study-linter

--- a/.github/workflows/sync-brand-pack.yml
+++ b/.github/workflows/sync-brand-pack.yml
@@ -12,16 +12,18 @@ name: sync-brand-pack
 #   *** AUTH ***
 #   skylight-hub is PRIVATE. The default GITHUB_TOKEN (scoped to this repo)
 #   cannot read it, and unauthenticated raw.githubusercontent fetches 404.
-#   So this sync fetches via the GitHub contents API using a HUB_READ_TOKEN
-#   secret (a fine-grained PAT with contents:read on skylight-hq/skylight-hub).
-#   Until that secret is added, the sync SKIPS with a warning (non-blocking)
-#   so the workflow stays mergeable and self-activates once the secret lands.
-#   The same secret activates the case-study-lint gate.
+#   So this sync fetches via the GitHub contents API using a short-lived token
+#   minted from the federation GitHub App (Contents:Read, scoped to
+#   skylight-hub, ~1h TTL) — no long-lived PAT. Until the App is configured
+#   (FEDERATION_APP_ID variable + FEDERATION_APP_PRIVATE_KEY secret, App
+#   installed on skylight-hq/skylight-hub), the sync SKIPS with a warning
+#   (non-blocking) so the workflow stays mergeable and self-activates. The
+#   same App config activates the case-study-lint gate.
 #
 #   NOTE: the companion brand-pack-freshness.yml job fails when a vendored
-#   file's synced_at is >30 days old. If this sync stays inactive (no token),
-#   the brand files will eventually trip that freshness gate — adding the
-#   secret resolves both.
+#   file's synced_at is >30 days old. If this sync stays inactive (no App),
+#   the brand files will eventually trip that freshness gate — configuring the
+#   App resolves both.
 
 on:
   schedule:
@@ -46,10 +48,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Mint a short-lived token from the federation GitHub App to read the
+      # brand-pack canon out of the private skylight-hub repo. Guarded so the
+      # sync self-skips until the App is configured.
+      - name: Mint hub-read App token
+        id: app-token
+        if: ${{ vars.FEDERATION_APP_ID != '' }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.FEDERATION_APP_ID }}
+          private-key: ${{ secrets.FEDERATION_APP_PRIVATE_KEY }}
+          owner: skylight-hq
+          repositories: skylight-hub
+
       - name: Detect hub-access token
         id: cfg
         env:
-          HUB_TOKEN: ${{ secrets.HUB_READ_TOKEN }}
+          HUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if [ -n "$HUB_TOKEN" ]; then
             echo "ok=true" >> "$GITHUB_OUTPUT"
@@ -60,14 +75,14 @@ jobs:
       - name: Sync inactive notice
         if: steps.cfg.outputs.ok != 'true'
         run: |
-          echo "::warning title=sync-brand-pack inactive::skylight-hub is private; this sync needs a HUB_READ_TOKEN secret (fine-grained PAT, contents:read on skylight-hq/skylight-hub) to fetch the brand-pack canon. Skipping (non-blocking) until it's added. The same secret activates the case-study-lint gate."
+          echo "::warning title=sync-brand-pack inactive::skylight-hub is private; this sync needs the federation GitHub App configured (FEDERATION_APP_ID variable + FEDERATION_APP_PRIVATE_KEY secret, App installed on skylight-hq/skylight-hub) to fetch the brand-pack canon. Skipping (non-blocking) until then. The same App config activates the case-study-lint gate."
           echo "Sync skipped — see warning above."
 
       - name: Resolve source default branch + SHA
         if: steps.cfg.outputs.ok == 'true'
         id: src
         env:
-          GH_TOKEN: ${{ secrets.HUB_READ_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           BRANCH=$(gh api repos/${SOURCE_REPO} --jq '.default_branch')
           SHA=$(gh api repos/${SOURCE_REPO}/branches/${BRANCH} --jq '.commit.sha')
@@ -79,7 +94,7 @@ jobs:
         if: steps.cfg.outputs.ok == 'true'
         id: fetch
         env:
-          GH_TOKEN: ${{ secrets.HUB_READ_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -uo pipefail
           BRANCH="${{ steps.src.outputs.branch }}"


### PR DESCRIPTION
## What

Migrates both skylight.digital workflows that read the private skylight-hub repo from the **`HUB_READ_TOKEN`** fine-grained PAT to short-lived tokens minted from the **federation GitHub App** (Contents:Read, scoped to skylight-hub, ~1h TTL):

- **`case-study-lint.yml`** — checks out the canonical case-study linter from hub.
- **`sync-brand-pack.yml`** — fetches the brand-pack canon from hub via the contents API.

Same self-skip-when-unconfigured behavior, now keyed on `vars.FEDERATION_APP_ID` + `secrets.FEDERATION_APP_PRIVATE_KEY` (set on this repo), with the App installed on skylight-hub.

## Why

Consolidating all federation cross-repo auth onto the org-owned, ephemeral App and retiring the long-lived PATs. This retires skylight.digital's only `HUB_READ_TOKEN` consumers.

## Verification (both dispatched on this branch, green)

- `case-study-lint` [run 27028836774](https://github.com/skylight-hq/skylight.digital/actions/runs/27028836774): minted hub token → checked out hub linter → all 64 case studies pass.
- `sync-brand-pack` [run 27028960273](https://github.com/skylight-hq/skylight.digital/actions/runs/27028960273): minted hub token → gh-api read of hub brand-pack → no-op (already in sync).

After this + the people-ops follow-up, `HUB_READ_TOKEN` + `FEDERATION_TOKEN` can be revoked.