### PR TITLE
ci: skip App token on Dependabot; migrate app-id -> client-id (v3)

### DIFF
--- a/.github/workflows/case-study-lint.yml
+++ b/.github/workflows/case-study-lint.yml
@@ -15,7 +15,7 @@ name: case-study-lint
 #
 #   *** ACTIVATION ***
 #   The gate self-activates when the App is configured for this repo: the
-#   FEDERATION_APP_ID variable + FEDERATION_APP_PRIVATE_KEY secret, with the
+#   FEDERATION_APP_CLIENT_ID variable + FEDERATION_APP_PRIVATE_KEY secret, with the
 #   App installed on skylight-hq/skylight-hub. Until then the token step is
 #   skipped and the gate SKIPS with a warning, so this workflow merges cleanly.
 
@@ -51,10 +51,14 @@ jobs:
       # gate self-skips until the App is configured.
       - name: Mint hub-read App token
         id: app-token
-        if: ${{ vars.FEDERATION_APP_ID != '' }}
-        uses: actions/create-github-app-token@v1
+        # Skipped on Dependabot PRs (their runs can't read the App private-key
+        # secret); continue-on-error covers fork PRs. The gate then self-skips
+        # below (cfg.ok=false → "gate inactive" notice), keeping the check green.
+        if: ${{ vars.FEDERATION_APP_CLIENT_ID != '' && github.actor != 'dependabot[bot]' }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.FEDERATION_APP_ID }}
+          client-id: ${{ vars.FEDERATION_APP_CLIENT_ID }}
           private-key: ${{ secrets.FEDERATION_APP_PRIVATE_KEY }}
           owner: skylight-hq
           repositories: skylight-hub
@@ -74,7 +78,7 @@ jobs:
         if: steps.cfg.outputs.ok != 'true'
         run: |
           echo "::warning title=case-study-lint inactive::Federation GitHub App not configured " \
-               "(needs the FEDERATION_APP_ID variable + FEDERATION_APP_PRIVATE_KEY secret, with the " \
+               "(needs the FEDERATION_APP_CLIENT_ID variable + FEDERATION_APP_PRIVATE_KEY secret, with the " \
                "App installed on skylight-hq/skylight-hub). The case-study taxonomy gate is not " \
                "enforcing. Skipping for now (non-blocking)."
           echo "Gate skipped — see warning above."

--- a/.github/workflows/sync-brand-pack.yml
+++ b/.github/workflows/sync-brand-pack.yml
@@ -15,7 +15,7 @@ name: sync-brand-pack
 #   So this sync fetches via the GitHub contents API using a short-lived token
 #   minted from the federation GitHub App (Contents:Read, scoped to
 #   skylight-hub, ~1h TTL) — no long-lived PAT. Until the App is configured
-#   (FEDERATION_APP_ID variable + FEDERATION_APP_PRIVATE_KEY secret, App
+#   (FEDERATION_APP_CLIENT_ID variable + FEDERATION_APP_PRIVATE_KEY secret, App
 #   installed on skylight-hq/skylight-hub), the sync SKIPS with a warning
 #   (non-blocking) so the workflow stays mergeable and self-activates. The
 #   same App config activates the case-study-lint gate.
@@ -53,10 +53,10 @@ jobs:
       # sync self-skips until the App is configured.
       - name: Mint hub-read App token
         id: app-token
-        if: ${{ vars.FEDERATION_APP_ID != '' }}
-        uses: actions/create-github-app-token@v1
+        if: ${{ vars.FEDERATION_APP_CLIENT_ID != '' }}
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.FEDERATION_APP_ID }}
+          client-id: ${{ vars.FEDERATION_APP_CLIENT_ID }}
           private-key: ${{ secrets.FEDERATION_APP_PRIVATE_KEY }}
           owner: skylight-hq
           repositories: skylight-hub
@@ -75,7 +75,7 @@ jobs:
       - name: Sync inactive notice
         if: steps.cfg.outputs.ok != 'true'
         run: |
-          echo "::warning title=sync-brand-pack inactive::skylight-hub is private; this sync needs the federation GitHub App configured (FEDERATION_APP_ID variable + FEDERATION_APP_PRIVATE_KEY secret, App installed on skylight-hq/skylight-hub) to fetch the brand-pack canon. Skipping (non-blocking) until then. The same App config activates the case-study-lint gate."
+          echo "::warning title=sync-brand-pack inactive::skylight-hub is private; this sync needs the federation GitHub App configured (FEDERATION_APP_CLIENT_ID variable + FEDERATION_APP_PRIVATE_KEY secret, App installed on skylight-hq/skylight-hub) to fetch the brand-pack canon. Skipping (non-blocking) until then. The same App config activates the case-study-lint gate."
           echo "Sync skipped — see warning above."
 
       - name: Resolve source default branch + SHA


### PR DESCRIPTION
**What:** Harden the federation GitHub-App token steps so Dependabot PRs stop red-failing, and retire the deprecated `app-id` input.

**Why:** Dependabot runs can't read the `FEDERATION_APP_PRIVATE_KEY` secret, so `create-github-app-token` errored on an empty key and failed the check (forcing admin-merges). `app-id` is also deprecated in favor of `client-id`.

**How:** token step now `if: github.actor != 'dependabot[bot]'` + `continue-on-error` (covers forks); each workflow's existing fallback then runs (lychee skipped with a green notice / federation check local-only / gate inactive). Switched to `client-id: ${{ vars.FEDERATION_APP_CLIENT_ID }}` and bumped to `@v3`. The `FEDERATION_APP_CLIENT_ID` variable is already set in this repo.

CI on this PR exercises the normal (non-Dependabot) path with the token present.