### PR TITLE
chore: standardize commit metadata + align workflow action versions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "includeCoAuthoredBy": false,
   "extraKnownMarketplaces": {
     "skylight-hub": {
       "source": {

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download prodBuild
         uses: actions/download-artifact@v4.1.7
         with:


### PR DESCRIPTION
Federation-hardening W7.1 + W8.5: includeCoAuthoredBy:false in the checked-in Claude settings, and actions/checkout v3->v4 to match the federation baseline.