### PR TITLE
ci(supply-chain): SHA-pin every GitHub Action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Dependabot keeps the SHA-pinned GitHub Actions fresh: it understands
+# commit-SHA pins and opens bump PRs (updating the trailing version comment)
+# that land through the normal required-check gates.
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/workflows/asset-manifests.yml
+++ b/.github/workflows/asset-manifests.yml
@@ -26,8 +26,8 @@ jobs:
     name: Validate asset manifests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
         with:
           ruby-version: '3.2'
       - name: Validate every asset manifest in the repo

--- a/.github/workflows/brand-pack-freshness.yml
+++ b/.github/workflows/brand-pack-freshness.yml
@@ -34,7 +34,7 @@ jobs:
       MAX_AGE_DAYS: 30
       DATA_DIR: _data/brand
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Check synced_at across vendored brand-pack files
         run: |
           set -euo pipefail

--- a/.github/workflows/case-study-lint.yml
+++ b/.github/workflows/case-study-lint.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout skylight.digital
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Mint a short-lived token from the federation GitHub App to read the
       # canonical linter out of the private skylight-hub repo. Guarded so the
@@ -56,7 +56,7 @@ jobs:
         # below (cfg.ok=false → "gate inactive" notice), keeping the check green.
         if: ${{ vars.FEDERATION_APP_CLIENT_ID != '' && github.actor != 'dependabot[bot]' }}
         continue-on-error: true
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.FEDERATION_APP_CLIENT_ID }}
           private-key: ${{ secrets.FEDERATION_APP_PRIVATE_KEY }}
@@ -85,7 +85,7 @@ jobs:
 
       - name: Checkout skylight-hub linter (canon)
         if: steps.cfg.outputs.ok == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: skylight-hq/skylight-hub
           token: ${{ steps.app-token.outputs.token }}
@@ -96,7 +96,7 @@ jobs:
 
       - name: Set up Ruby
         if: steps.cfg.outputs.ok == 'true'
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
         with:
           ruby-version: '3.2'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,14 +31,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 18
           cache: "npm"
@@ -46,14 +46,14 @@ jobs:
         run: npm ci
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@c5a3e1159e0cbdf0845eb8811bd39e39fc3099c2 # v2
       - name: Build with Jekyll
         run: bundle exec jekyll build
         env:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           # The path to the directory to upload
           path: ./build
@@ -69,7 +69,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
         with:
           artifact_name: prodBuild
 
@@ -79,9 +79,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Download prodBuild
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: prodBuild
       - name: Unzip artifact
@@ -89,7 +89,7 @@ jobs:
           mkdir ./build
           tar -xf artifact.tar -C ./build
       - name: Audit URLs using Lighthouse
-        uses: treosh/lighthouse-ci-action@v9
+        uses: treosh/lighthouse-ci-action@2e159d989f91bb9e399801b3e1ad90bcd4749f75 # v9
         with:
           configPath: './lighthouserc.yml'
           uploadArtifacts: false # save results as an action artifacts

--- a/.github/workflows/sync-brand-pack.yml
+++ b/.github/workflows/sync-brand-pack.yml
@@ -46,7 +46,7 @@ jobs:
       SOURCE_DIR: plugins/skylight-brand-pack/config
       FILES: colors.yml typography.yml logo-rules.yml voice-tone.yml brand-narrative.yml illustration.yml customer-brand-rules.yml icons.yml imagery.yml
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Mint a short-lived token from the federation GitHub App to read the
       # brand-pack canon out of the private skylight-hub repo. Guarded so the
@@ -54,7 +54,7 @@ jobs:
       - name: Mint hub-read App token
         id: app-token
         if: ${{ vars.FEDERATION_APP_CLIENT_ID != '' }}
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.FEDERATION_APP_CLIENT_ID }}
           private-key: ${{ secrets.FEDERATION_APP_PRIVATE_KEY }}
@@ -155,7 +155,7 @@ jobs:
 
       - name: Open / update PR with changes
         if: steps.cfg.outputs.ok == 'true' && steps.fetch.outputs.any_changed == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: sync/brand-pack


### PR DESCRIPTION
Mirrors skylight-hub: all action references pinned to full-length commit SHAs with version comments; Dependabot keeps them fresh.