### PR TITLE
ci(pages): inline Pages artifact packaging — upload-pages-artifact trips the SHA-pinning policy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,13 +51,19 @@ jobs:
         run: bundle exec jekyll build
         env:
           JEKYLL_ENV: production
+      - name: Package site artifact (Pages tar)
+        # Inlined from actions/upload-pages-artifact: that composite action
+        # references actions/upload-artifact@v4 by TAG internally, which the
+        # require-SHA-pinning policy rejects at job setup ("The action
+        # actions/upload-artifact@v4 is not allowed... must be pinned to a
+        # full-length commit SHA"). Same tar semantics as the composite.
+        run: tar --dereference --hard-dereference --directory ./build -cf "$RUNNER_TEMP/artifact.tar" .
       - name: Upload artifact
-        # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          # The path to the directory to upload
-          path: ./build
+          path: ${{ runner.temp }}/artifact.tar
           name: prodBuild
+          retention-days: 1
 
   # Deployment job
   deploy:


### PR DESCRIPTION
The Pages deploy [failed at **Set up job**](https://github.com/skylight-hq/skylight.digital/actions/runs/28889656230) on today's merges — the first `master` pushes since `sha_pinning_required` was enabled on this repo. Root cause: `actions/upload-pages-artifact` is a **composite** action that references `actions/upload-artifact@v4` by tag *internally*, and the policy checks transitive references, so the job is rejected before any step runs. (Not caused by the Dependabot bumps — they just triggered the first deploy under the policy.)

**Fix (keeps the pinning posture):** inline the composite's two steps — the identical `tar --dereference --hard-dereference` packaging plus `actions/upload-artifact` pinned to the v7.0.1 SHA already in use here. Artifact name (`prodBuild`), tar layout, and both consumers (`deploy-pages` v5, `validate-site`'s `tar -xf`) unchanged.

Real verification is the post-merge `master` deploy run (this workflow only runs on push to master + dispatch) — I'll watch it end-to-end after merging.