### PR TITLE
fix(deps): drop the vestigial cryptiles pin — clears the hoek HIGH alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "kind-of": ">=6.0.3"
       },
       "devDependencies": {
-        "cryptiles": ">=4.1.2",
         "extend": ">=3.0.2",
         "grunt-cli": "^1.4.3",
         "kind-of": ">=6.0.3",
@@ -57,33 +56,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/cryptiles": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.3.tgz",
-      "integrity": "sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw==",
-      "deprecated": "This module has moved and is now available at @hapi/cryptiles. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
-      "dev": true,
-      "dependencies": {
-        "boom": "7.x.x"
-      }
-    },
-    "node_modules/cryptiles/node_modules/boom": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
-      "integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
-      "deprecated": "This module has moved and is now available at @hapi/boom. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
-      "dev": true,
-      "dependencies": {
-        "hoek": "6.x.x"
-      }
-    },
-    "node_modules/cryptiles/node_modules/hoek": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
-      "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "dev": true
     },
     "node_modules/detect-file": {
       "version": "1.0.0",
@@ -724,32 +696,6 @@
       "dev": true,
       "requires": {
         "fill-range": "^7.1.1"
-      }
-    },
-    "cryptiles": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.3.tgz",
-      "integrity": "sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw==",
-      "dev": true,
-      "requires": {
-        "boom": "7.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
-          "integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x"
-          }
-        },
-        "hoek": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
-          "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q==",
-          "dev": true
-        }
       }
     },
     "detect-file": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "kind-of": ">=6.0.3"
   },
   "devDependencies": {
-    "cryptiles": ">=4.1.2",
     "extend": ">=3.0.2",
     "grunt-cli": "^1.4.3",
     "kind-of": ">=6.0.3",


### PR DESCRIPTION
Clears [Dependabot alert #21](https://github.com/skylight-hq/skylight.digital/security/dependabot/21) (HIGH — `hoek` ≤ 6.1.3 prototype pollution, **no patched version exists**; the package is EOL) at the source instead of dismissing it.

**Trace:** `hoek` enters only via `cryptiles` (`node_modules/cryptiles/node_modules/hoek`) — and `cryptiles` is not a real dependency of anything. It sits in `devDependencies` as a bare `>=4.1.2` floor-pin from the same security-bump era as the `kind-of`/`extend`/`minimist` pins, with **zero dependents in the lock** besides the root and zero references anywhere in the build (the npm scripts are Ruby/docker wrappers; CI's only npm usage is `npm ci`). Removing the pin removes `cryptiles → boom → hoek` entirely.

**Diff:** 54 pure deletions in the lock (lockfileVersion stays 2) + one line in package.json.

**Verified:** `npm ci` clean against the regenerated lock · `npm ls hoek` → empty · `npm audit` no longer reports the HIGH (one unrelated **moderate** remains — out of scope here). Runtime exposure was nil regardless (static Jekyll site; npm is build tooling only). The alert should auto-resolve after this merges to `master` — I'll confirm.

**Observed in passing, not touched:** `Gruntfile.js` loads `grunt-accessibility`, which isn't in `devDependencies` (the grunt task would fail if invoked) — the npm layer looks largely vestigial and could use its own cleanup pass.