### PR TITLE
fix: repair a case study link that 404s in production

### DIFF
--- a/_projects/ct_families_experiencing_homelessness.md
+++ b/_projects/ct_families_experiencing_homelessness.md
@@ -41,7 +41,7 @@ source_code_url:
 ---
 
 {% capture summary %}
-As part of our [digital transformation work with Connecticut’s Office of Early Childhood](/work/experience/ct-oec-transformation/), we helped the state develop a clearer, data-driven approach to identifying and supporting families with young children experiencing homelessness. The work improved how providers prioritize families for housing and services.
+As part of our [digital transformation work with Connecticut’s Office of Early Childhood](/work/experience/ct-oec-digital-transformation/), we helped the state develop a clearer, data-driven approach to identifying and supporting families with young children experiencing homelessness. The work improved how providers prioritize families for housing and services.
 {% endcapture %}
 
 {% capture challenge %}


### PR DESCRIPTION
## The bug

`_projects/ct_families_experiencing_homelessness.md:44` links to `/work/experience/ct-oec-transformation/`. The target case study's actual permalink is `/work/experience/ct-oec-digital-transformation/`.

Verified against **production**, not just the repo:

| URL | Status |
|---|---|
| `/work/experience/ct-oec-transformation/` (linked) | **404** |
| `/work/experience/ct-oec-digital-transformation/` (real) | 200 |

One case study 404ing into another, on the sales surface, right now. One-line fix.

## Why nothing caught it

`package.json` has an `html-lint` script — `bundle exec htmlproofer ./build` — but **html-proofer is not in the Gemfile**, so the script has been dead. Wiring it up is a sensible follow-up; this PR just fixes the live bug.

## Verification

Once the Netlify deploy preview builds, the corrected link resolves within the preview.