### PR TITLE
fix(a11y): drop tab roles from the collapse-based accordion

### DIFF
--- a/_includes/accordion.html
+++ b/_includes/accordion.html
@@ -1,9 +1,8 @@
 <!-- Accordion card -->
-<div class="card accordion-card" role="tablist">
+<div class="card accordion-card">
   <!-- Card header -->
   <div
     class="accordion-header"
-    role="tab"
     id="accordionHeading-{{include.accordion_index}}"
   >
     <a
@@ -25,7 +24,6 @@
   <div
     id="accordionCollapse-{{include.accordion_index}}"
     class="collapse"
-    role="tabpanel"
     aria-labelledby="accordionHeading-{{include.accordion_index}}"
   >
     <div class="card-body accordion-card-body">

--- a/_includes/filter_component.html
+++ b/_includes/filter_component.html
@@ -48,11 +48,10 @@
   <div class="post-tags filter-post-tags"></div>
 
   <!-- Accordion card -->
-  <div class="card accordion-card accordion-filter" role="tablist">
+  <div class="card accordion-card accordion-filter">
     <!-- Card header -->
     <div
       class="accordion-header"
-      role="tab"
       id="accordionHeading-{{include.accordion_index}}"
     >
       <a
@@ -77,7 +76,6 @@
     <div
       id="accordionCollapse-{{include.accordion_index}}"
       class="collapse"
-      role="tabpanel"
       aria-labelledby="accordionHeading-{{include.accordion_index}}"
     >
       <div class="card-body accordion-card-body">


### PR DESCRIPTION
## The bug

`_includes/accordion.html` and `_includes/filter_component.html` are Bootstrap **collapse** widgets wearing **tab** roles:

```html
<div class="card accordion-card" role="tablist">
  <div class="accordion-header" role="tab">...<a data-toggle="collapse" aria-expanded="false">
  <div class="collapse" role="tabpanel" aria-labelledby="...">
```

Two ARIA defects fall out:

- **`aria-required-children`** — a `tablist`'s only permitted owned children are `tab`s. Here it also owns the `tabpanel`.
- **`nested-interactive`** — the `role="tab"` div wraps an interactive `<a>`.

More fundamentally: these roles promise arrow-key tab navigation that Bootstrap collapse **never implements**. Declaring semantics the widget doesn't honour is worse for a screen-reader user than declaring none. The retained `aria-expanded` / `aria-controls` / `aria-labelledby` already describe a **disclosure**, which is what this actually is.

**Renders on 67 pages, including all 64 case studies** — the artifacts that assert 508 competence to government buyers.

## Why this is safe

The obvious risk is styling that hangs off the roles. I checked before cutting:

- The only CSS selecting on them is `[role="tabpanel"][aria-expanded="true"]` (`_sass/_accordion.scss:53`).
- Bootstrap puts `aria-expanded` on the **trigger** `<a>`, never on the panel — the built panel is `<div id="accordionCollapse-0" class="collapse" role="tabpanel" aria-labelledby="...">`.
- So **zero elements in the built site match that selector**. It is already dead; removing the role can't change rendering.

Nothing in `js/` selects on the roles either — Bootstrap collapse binds on `data-toggle="collapse"`.

## Verification

Deploy preview: confirm an accordion (e.g. any case study) still opens/closes and looks unchanged.

## Noticed, not touched

- `_sass/abstracts/_variables.scss:602-741` is a **byte-identical copy of the entire `_accordion.scss`** (all 139 lines), including this same dead selector. Pre-existing; worth its own PR.
- `[role="tabpanel"][aria-expanded="true"]` is now unambiguously dead in both copies. Left in place rather than expanding this PR's blast radius.