### PR TITLE
chore: remove the orphaned lighthouse config

### DIFF
--- a/lighthouse/lighthouserc.yml
+++ b/lighthouse/lighthouserc.yml
@@ -1,7 +1,0 @@
-ci:
-  collect:
-    numberOfRuns: 1
-  assert:
-    assertions:
-      categories:accessibility: [error, {minScore: 0.97}]
-      categories:performance: [warn, {minScore: 0.8}]


### PR DESCRIPTION
## What

`lighthouse/lighthouserc.yml` is dead. `main.yml`'s `validate-site` job passes `configPath: './lighthouserc.yml'` — the **root** config. The `lighthouse/` copy is referenced by no workflow, no `netlify.toml`, and no `package.json` script. Verified with a repo-wide grep across `*.yml`/`*.yaml`/`*.toml`/`*.json`/`*.md`: **zero references**.

## What it remembers (recorded here because deleting drops the evidence)

The orphan isn't a stray file — it has five commits of genuine tuning (*"Adjust error score"*, *"Update error levels"*). It was the live config from ~2020 until the Dec 2022 reconfigure moved config to the repo root.

Comparing the two:

| | orphan (`lighthouse/lighthouserc.yml`) | live (`lighthouserc.yml`) |
|---|---|---|
| accessibility | `error, minScore: 0.97` | `error, minScore: 0.9` |
| performance | `warn, minScore: 0.8` | *(none)* |
| numberOfRuns | 1 | *(default 3)* |

So the 2022 move **quietly dropped the a11y bar from 0.97 to 0.9 and deleted the performance gate** — invisible in that diff, unnoticed for ~3.5 years.

## Scope

Deleting the orphan only. Whether to restore the 0.97 bar is a separate call, and it belongs with fixing *what the check audits* rather than *how hard it grades* — see below.

## Related, not in this PR

`lighthouserc.yml` uses `maxAutodiscoverUrls: 20`. Pulled the actual audited URL list from the last `validate-site` run: it's the homepage, `/about/`, `/alliances/`, `/blog/index.html`, and ~16 `/blog/<post>/` pages — i.e. **alphabetical**, exhausted inside `/blog/` before ever reaching `/company/` or `/work/`.

The site builds 591 HTML pages, so that's ~3.4% coverage, and **0 of the 67 accordion pages** (all under `/work/` and `/company/`) are ever audited — including the `aria-required-children` defect fixed in #584. Re-aiming at an explicit URL list is the real fix, but `validate-site` only runs on `push: master`, so that change can't be verified in a PR — it needs a `workflow_dispatch` run after merge. Deliberately left out of this one.