### PR TITLE
chore(ci): retire the npm layer from the build job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,13 +37,6 @@ jobs:
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
-      - name: Setup Node
-        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
-        with:
-          node-version: 18
-          cache: "npm"
-      - name: Install node dependencies
-        run: npm ci
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@c5a3e1159e0cbdf0845eb8811bd39e39fc3099c2 # v2


### PR DESCRIPTION
Closes #580.

## Why not just merge #580?

**The bump is safe.** I went looking for a reason to reject it and didn't find one — every breaking change across setup-node v4/v5/v6 either doesn't apply or is provably benign here. The most likely candidate (`cache: npm` choking on a zero-dependency lockfile) is dead on inspection: `findLockFile()` is byte-identical between the two SHAs and never inspects dependency *count*, only whether the file exists.

**But safe and worth-it are different questions.** The bump's entire payoff is that a step which installs nothing continues to install nothing, on a newer runtime.

| | |
|---|---|
| `package-lock.json` packages tree | root stanza only → **`npm ci` installs 0 packages** |
| `package.json` deps / devDeps | **none** — all 3 scripts shell out to `bundle exec` or docker |
| Gems needing a JS runtime | **zero** (no execjs, coffee, uglifier, therubyracer, mini_racer, duktape) |
| JS build tooling | none (no Gruntfile/gulp/webpack/rollup); both `_plugins` are Ruby |

## The risk read is inverted here

"Delete is the bigger diff, so it's riskier" is the natural intuition and it's **wrong in this repo**:

- **The deletion is validated by an existing green workflow.** `pr-build.yml` (#582) runs exactly checkout + setup-ruby + `bundle exec jekyll build`, with no setup-node and no npm — that *is* the post-deletion build path, and it's green on master.
- **The bump is validated by nothing.** `pr-build.yml` deliberately excludes npm, and `main.yml` never runs until the push to master that also deploys. There is no pre-merge test for it.

The bigger diff is the better-evidenced one.

## Worst case

Unchanged either way, and it's fail-safe: `deploy` is `needs: build`, so a build failure means deploy never runs and skylight.digital keeps serving the last good deploy. The site goes **stale, not broken**. The difference is that after this, there's no setup-node/npm step left that *can* fail — ever again. `ubuntu-latest` ships Node preinstalled, so `node`/`npm` remain on PATH regardless.

## Also ends the noise

setup-node **v6.5.0 shipped the same day #580 was opened**. Merging #580 earns a fresh PR almost immediately; deleting the step is the only thing that ends the loop. `@dependabot ignore` would just hide a live failure surface instead of removing it.

## Scope

Keeps `package.json` and `package-lock.json` — `package.json` still earns its place as the local-dev script holder, and with no deps it generates no Dependabot traffic (`dependabot.yml` registers only the `github-actions` ecosystem). This completes the cleanup #579 started.