### PR TITLE
fix(ci): author the sync PR with the App token so its checks run

### DIFF
--- a/.github/workflows/sync-brand-pack.yml
+++ b/.github/workflows/sync-brand-pack.yml
@@ -68,6 +68,32 @@ jobs:
           owner: skylight-hq
           repositories: skylight-hub
 
+      # A second, separately-scoped token — this one WRITES, and only to this
+      # repo. It exists because a PR authored via the default GITHUB_TOKEN does
+      # not trigger workflows (GitHub's loop prevention), so the sync PR would
+      # arrive with no `Build the site` check. That check is now a required
+      # status check on master, so such a PR is unmergeable without an admin
+      # override. An App-authored PR triggers workflows normally and merges on
+      # its own merits.
+      #
+      # continue-on-error + the GITHUB_TOKEN fallback below mean this can only
+      # improve on the status quo: if the App lacks write on this repo the mint
+      # fails, the sync still opens its PR exactly as it does today, and the
+      # step starts working the moment the permission is granted. Mirrors the
+      # pr-token pattern in skylight-hub's vendored-content-sync.yml.
+      - name: Mint federation App token (PR authoring — write, this repo only)
+        id: pr-token
+        if: ${{ vars.FEDERATION_APP_CLIENT_ID != '' }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ vars.FEDERATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.FEDERATION_APP_PRIVATE_KEY }}
+          owner: skylight-hq
+          repositories: skylight.digital
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Detect hub-access token
         id: cfg
         env:
@@ -173,7 +199,7 @@ jobs:
         if: steps.cfg.outputs.ok == 'true' && steps.fetch.outputs.any_changed == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.pr-token.outputs.token || secrets.GITHUB_TOKEN }}
           branch: sync/brand-pack
           commit-message: |
             chore(brand-pack): sync from skylight-hub@${{ steps.src.outputs.sha }}


### PR DESCRIPTION
## The bug I introduced today

Making `Build the site` a **required** status check on `master` had a side effect I missed: `sync-brand-pack.yml` opens its PR with `token: ${{ secrets.GITHUB_TOKEN }}`, and **GitHub's loop prevention means a PR created with the default `GITHUB_TOKEN` triggers no workflows**. So the sync PR arrives with no `Build the site` status — and an unsatisfiable required check.

**Verified, not inferred:**

| PR | Author | Actions checks |
|---|---|---|
| #576 | `app/github-actions` | **none** — only Netlify (a webhook integration) |
| #575 | `cscairns` (human) | got the `freshness` check |

#576 touches `_data/brand/**` and `brand-pack-freshness.yml` filters on exactly that path — it still didn't run. That's conclusive.

**Timing:** next sync is ~**2026-07-27** (`synced_at` 2026-07-06 + `REFRESH_AGE_DAYS: 21`). Freshness would go red **2026-08-05**.

## The fix

Mint a second, separately-scoped App token that can write to **this repo only**, and author the PR with it. App-authored PRs trigger workflows normally, so the sync PR gets its `Build the site` check and merges on its own merits.

This is not a new invention — it mirrors the `pr-token` pattern already reviewed and running in `skylight-hub`'s [`vendored-content-sync.yml`](https://github.com/skylight-hq/skylight-hub/blob/main/.github/workflows/vendored-content-sync.yml) and `federation-inventory.yml`.

## Why it can't regress

I kept the hub's `continue-on-error: true` + `|| secrets.GITHUB_TOKEN` fallback:

- **App has write here** → PR is App-authored, checks run, merges cleanly.
- **App lacks write here** → mint fails quietly, the sync opens its PR *exactly as it does today*, and the step self-heals the moment the permission is granted.

Strictly a superset of current behavior. Worst case is the status quo.

## On whether the permission exists

The App **already authors PRs in the hub** — e.g. hub #241, author `app/skylight-federation-assets` — and the hub's `pr-token` step reports `success` on recent runs. So App-level write is granted. What's unproven is whether the installation extends write to *this* repo; the fallback makes that safe to find out.

Worth noting the hub's comments on both those workflows say *"until the App's write permission is granted"* — that now looks **stale**, given `pr-token` succeeds and #241 is App-authored. Separate repo, so not touched here.

## Meanwhile

Until the first sync PR proves it out, the fallback path still needs either an admin override or a close+reopen (a human reopen fires `pull_request.reopened`, which *does* trigger workflows).