### PR TITLE
brand: data-drive illustration/principles.md from _data/brand/ (Phase 7.5)

### DIFF
--- a/pages/company/brand/illustration/principles.md
+++ b/pages/company/brand/illustration/principles.md
@@ -19,35 +19,12 @@ redirect_from:
 The following six principles will help you design effective Skylight illustrations.
 
 <div class="example" markdown="1">
-## 1. Highlight impact
+{%- assign illustration = site.data.brand.illustration -%}
+{%- for principle in illustration.principles %}
+## {{ forloop.index }}. {{ principle.name }}
 
-Demonstrate the impact of our mission and the work that we do. We want people to understand why working with us benefits them and society.
-
-## 2. Humanize
-
-People are at the center of our work. Embody this by incorporating human elements such as a person’s full body, face, or hands.
-
-Typically, illustrations with objects only are reserved for icons.
-
-## 3. Digitize
-
-Show people interacting with technology, ​​or in visual metaphors about the physical and digital world intersecting.
-
-In some cases, it might be more compelling to focus on the ultimate outcomes of our work rather than the technology or methods that we use.
-
-## 4. Simplify
-
-As a company, we aim to turn complex problems into the simplest solutions possible. Employ metaphors to translate the complexity of the problem and solution spaces in which we operate into widely understandable visuals. Because this method tends to be more accessible and memorable, avoid literal drawings.
-
-## 5. Diversify
-
-Reflect the diversity of the world that we live in — skin colors, body types, facial features (such as hair), age, abilities, style (such as clothing).
-
-## 6. Contextualize
-
-Keep in mind the purpose that the illustration is intended to serve.
-
-For example, if the illustration will accompany a case study or blog post, reinforce what we’re trying to accomplish within the text — that is, what we’re trying to communicate to the target audience.
+{{ principle.description }}
+{% endfor -%}
 </div>
 </div>
 </div>


### PR DESCRIPTION
Part of **HUB-A-021** — the first of Phase 7.5's four canon-ready pages.

## What

Wires the six core principles to `site.data.brand.illustration.principles` instead of hardcoding them, using the `assign` + `for` pattern #552 established on `voice_and_tone.md`. Net **−28/+5** lines.

## ⚠️ This is not a no-op — read this bit

Five of the six principles are **byte-identical** between canon and page. The sixth is not:

| | |
|---|---|
| **Live page today** | **5. Diversify** — "Reflect the **diversity of the world** that we live in — skin colors, body types, facial features (such as hair), age, abilities, style (such as clothing)." |
| **Canon** | **5. Represent everyone** — "Reflect the **full range of people** in the world that we live in — skin colors, body types, facial features (such as hair), age, abilities, style (such as clothing)." |

**This is decided canon, not accidental drift.** [hub #113](https://github.com/skylight-hq/skylight-hub/pull/113) renamed the principle to complete the terminology sweep in [hub #111](https://github.com/skylight-hq/skylight-hub/pull/111), which retired the DEI umbrella in favour of *"fairness, belonging, and accessibility"* per the existing content-guide standard. It landed **2026-05-30**; the website never received it because Phase 7.5 stalled after `identity/`.

So **merging this publishes that rename to the public brand site.** That's the intended effect — the website is supposed to follow canon, and this is exactly the gap Phase 7.5 exists to close — but it's a visible public terminology change rather than a silent refactor. Hence its own PR, with the diff stated plainly rather than buried in a −28/+5 diffstat.

If the rename should *not* go public yet, don't merge this — the canon and the page are then intentionally divergent and that's a different conversation.

## Verification

The failure mode here is silent: a typo'd data key renders **empty** with no error and a green build (verified earlier against the pinned Liquid 4.0.4). So a green check is necessary but not sufficient — the deploy preview is diffed against production before merge.

## Left alone

The intro still hardcodes *"The following **six** principles"*. Deriving that count is a copy change, not wiring — and `| size` yields `6`, not `six`.