### PR TITLE
brand: data-drive illustration/illustration_types.md prose (Phase 7.5)

### DIFF
--- a/pages/company/brand/illustration/illustration_types.md
+++ b/pages/company/brand/illustration/illustration_types.md
@@ -12,6 +12,8 @@ redirect_from:
   - /brand/illustration/illustration-types/
 ---
 
+{%- assign illustration = site.data.brand.illustration -%}
+
 <div class="brand__content-section grid">
   <header class="grid__heading" markdown="1">
 ## Featured post illustrations
@@ -39,9 +41,8 @@ redirect_from:
     </div>
   </div>
   <div class="grid__content" markdown="1">
-Illustrations for posts, such as a case study or blog article, use one or two (three if absolutely needed) bright colors from the illustration palette.
-
-These images are always full bleed with a background color.
+{%- assign t = illustration.types | where: "id", "featured-post" | first -%}
+{{ t.description }}
 </div>
 </div>
 
@@ -74,9 +75,8 @@ These images are always full bleed with a background color.
     </div>
   </div>
   <div class="grid__content" markdown="1">
-Floating images don’t have borders or any background color.
-
-They’re monochromatic using a bold color from the illustration palette. Accent with `gray-100` and sparingly with light gray.
+{%- assign t = illustration.types | where: "id", "floating-monochromatic" | first -%}
+{{ t.description }}
 </div>
 </div>
 
@@ -101,9 +101,8 @@ They’re monochromatic using a bold color from the illustration palette. Accent
     </div>
   </div>
   <div class="grid__content" markdown="1">
-Even though illustrations are monochromatic, pages or layouts with many floating images should rotate through the different primary Skylight colors.
-
-These images are used primarily within pages on the website.
+{%- assign t = illustration.types | where: "id", "floating-rotate-colors" | first -%}
+{{ t.description }}
 </div>
 </div>
 
@@ -120,11 +119,8 @@ These images are used primarily within pages on the website.
     <p class="caption">Mobile hero banner</p>
   </figure>
   <div class="grid__content" markdown="1">
-Hero banners are monochromatic.
-
-The base color uses a primary color and the rest of the illustration uses lighter or darker shades. Each section of the website uses one color.
-
-Hero banners are made of 2–4 illustration vignettes and the geometric shapes. The shapes are anchored to the vignettes and sprinkled throughout the layout to drive focus to the text.
+{%- assign t = illustration.types | where: "id", "heroes" | first -%}
+{{ t.description }}
 </div>
 </div>
 
@@ -155,8 +151,7 @@ Hero banners are made of 2–4 illustration vignettes and the geometric shapes. 
     </div>
   </div>
   <div class="grid__content" markdown="1">
-Portraits use 1–2 primary colors, as well as any skin and hair color needed.
-
-These images are always full bleed with a background color.
+{%- assign t = illustration.types | where: "id", "portraits" | first -%}
+{{ t.description }}
 </div>
 </div>


### PR DESCRIPTION
Part of **HUB-A-021** — second of Phase 7.5's canon-ready pages. Follows #588.

## What

Wires the five type descriptions to `site.data.brand.illustration.types`, looked up **by `id`** rather than by position, so reordering the canon can't silently shuffle the page.

## Scope: prose only, deliberately

Unlike `principles.md`, this page isn't a uniform list. Each section pairs a **bespoke image gallery** with its description:

- **Galleries stay hardcoded** — they're page-specific examples (project SVGs) with no canon equivalent.
- **Headings stay hardcoded** — the page renders `Floating illustrations: <br>monochromatic` with a layout break the canon `name` doesn't carry. Driving headings from canon would lose it.

## Drift check

Compared canon against page prose before touching anything: **4 of 5 byte-identical**. The fifth differs only in apostrophe glyph — canon `don't` vs page `don’t`. Kramdown's smart-quote conversion applies to Liquid output (already demonstrated on #588, where canon `person's` rendered as `person’s`), so the rendered result should be unchanged.

**Verified via the deploy-preview diff rather than assumed** — a wrong data key renders `""` with a green build, so a green check alone proves nothing here.