### PR TITLE
brand: retire the DEI umbrella on brand_narrative.md (Phase 7.5)

### DIFF
--- a/pages/company/brand/writing/brand_narrative.md
+++ b/pages/company/brand/writing/brand_narrative.md
@@ -48,7 +48,7 @@ We pursue **modern ways of working**. New trends and technologies are constantly
 
 We believe in the importance of **capacity building**. Regardless of mission, all government agencies are now technology organizations, which means they need to master disciplines such as human-centered design. Everything about us is designed to help our customers achieve such mastery.
 
-We strive to create a **diverse, equitable, and inclusive** environment for everyone.
+We strive to create an environment of **fairness, belonging, and accessibility** for everyone.
 </div>
 
 ## Brand personality
@@ -57,15 +57,10 @@ We strive to create a **diverse, equitable, and inclusive** environment for ever
 How we want the world to see us.
 
 <div class="example" markdown="1">
-**Mission oriented.** We’re driven by a burning passion to create better outcomes for the public through great government digital services.
-
-**Talented.** When you work with Skylight, you’re engaging with experts who are the best at what they do, and always deliver results — even when the going gets tough.
-
-**Modern.** Skylight possesses know-how in the latest, most-proven practices and technologies.
-
-**Lighthearted.** We’re approachable and easy to work with.
-
-**Welcoming.** We strive to create a diverse, equitable, and inclusive environment that’s welcoming to people of all identities and backgrounds.
+{%- assign narrative = site.data.brand["brand-narrative"] -%}
+{%- for trait in narrative.personality %}
+**{{ trait.name }}.** {{ trait.description }}
+{% endfor -%}
 
 **If Skylight were...**
 


### PR DESCRIPTION
Part of **HUB-A-021** — the last of Phase 7.5's canon-ready pages. Follows #588, #589, #590.

## What

The page carried **"diverse, equitable, and inclusive" in two places**, six weeks after [hub #111](https://github.com/skylight-hq/skylight-hub/pull/111) retired that umbrella in favour of **"fairness, belonging, and accessibility"** (matching the existing content-guide standard) and [hub #113](https://github.com/skylight-hq/skylight-hub/pull/113) completed the sweep.

Both now say what canon says.

| Section | Before | After |
|---|---|---|
| The Skylight difference | "We strive to create a **diverse, equitable, and inclusive** environment for everyone." | "We strive to create an environment of **fairness, belonging, and accessibility** for everyone." |
| Brand personality → Welcoming | "…create a diverse, equitable, and inclusive environment that's welcoming to…" | "…create an environment of fairness, belonging, and accessibility — welcoming to…" |

## Two mechanisms, because the sections aren't alike

- **Brand personality → wired** to `site.data.brand["brand-narrative"].personality`. The template supplies the `**{{ name }}.**` emphasis, so nothing is lost by driving it from canon.
- **The Skylight difference → corrected in place, still hardcoded.** Canon's `long` fields are plain text, but the page bolds a key phrase in each of the six bullets. Wiring it would strip the bold from all six — the same class of silent regression the render-diff caught on `visual_style` ([hub #249](https://github.com/skylight-hq/skylight-hub/pull/249)). The wording matches canon; the emphasis stays with the page.

Making canon carry emphasis so this section can be wired too is a real follow-up, but it was never a gate on the language.

## Why both, or neither

Fixing only the wired half would have left the page **self-contradictory** — "fairness, belonging, and accessibility" in one section and "diverse, equitable, and inclusive" in another. That's worse than either end state, and it's the thing that actually warranted care here. The language itself was decided on 2026-05-30.

## Deliberately untouched

`mission`, `sample_messaging`, `messaging`, and `analogy`. **`analogy` carries a `reading` field the live page doesn't show** — wiring it would *add* copy to the public site, which is a separate call, not a refactor.

## Verification

Deploy-preview diffed against production: expect exactly the two wording changes and no structural movement.