### PR TITLE
content-guide: retire the DEI umbrella, reconciling with the canonical base

### DIFF
--- a/pages/work/toolkits/content-guide/style_elements.md
+++ b/pages/work/toolkits/content-guide/style_elements.md
@@ -366,7 +366,7 @@ Use ampersands only if it's convention or if it's part of a company or brand nam
 #### Yes
 {: .passes }
 * Company: Ben & Jerry’s, AT&T
-* Convention: DE&I, R&D
+* Convention: R&D, Research & Design, Defense & Security
 </div>
 
 In all other cases, use “and” instead of an ampersand.

--- a/pages/work/toolkits/content-guide/word_list.md
+++ b/pages/work/toolkits/content-guide/word_list.md
@@ -51,7 +51,7 @@ If you don’t see a word here and aren’t sure what to do, check [AP style](ht
 
 **Defense & Security (DS)**
 
-**DE&I,** not DEI
+**DEI / DE&I / DEIAB.** Avoid. Skylight's substitute umbrella is “fairness, belonging, and accessibility,” spelled out rather than initialized. The concrete categories (age, disability, gender, race, religion, and so on) are covered in [writing inclusively](/work/toolkits/content-guide/writing-inclusively/).
 
 **DevOps**
 


### PR DESCRIPTION
## The contradiction

As of a few hours ago the **public site contradicts itself**:

| Page | Says |
|---|---|
| `/company/brand/writing/brand-narrative/` (#592) | "fairness, belonging, and accessibility" |
| `/work/toolkits/content-guide/word-list/` | **"DE&I, not DEI"** |
| `/work/toolkits/content-guide/style-elements/` | lists **DE&I** as a ✅ *Yes* example |

The guide that exists to settle terminology was teaching the retired form as correct.

## Which side is right

The hub's `standards/content-guide.md` self-declares **"This is the canonical base"** (`status: active`, `version: 2026.1`) and retired `DEI / DE&I / DEIAB` in [hub #111](https://github.com/skylight-hq/skylight-hub/pull/111). The published copy never followed.

**And nothing would have caught it.** The content guide is **not** in `standards/vendored-content.yml` and has **no sync workflow** — unlike the brand pack, which has both. These two copies drift silently, by construction. That's worth its own follow-up; this PR just closes the current gap.

## Changes

- **`word_list.md`** — `**DE&I,** not DEI` → the canon entry, with the canon's "Section 3" resolved to this site's [`/writing-inclusively/`](https://skylight.digital/work/toolkits/content-guide/writing-inclusively/) page (verified 200 — my first attempt pointed at `/inclusive-language/`, which 404s). Alphabetical position unchanged: `def` < `dei` < `dev`.
- **`style_elements.md`** — DE&I was a *Yes* example of the ampersand rule. **The rule is fine and stays**; only the example changes, to the canon's own set: `R&D, Research & Design, Defense & Security`.

## Left alone, deliberately

- **`building_a_modern_team_culture.md`** cites *"Diversity, Equity, and Inclusion at TTS"* — that's an **external page's actual title**. Not ours to rewrite.
- **A team bio in `_data/team.yml`** describes someone's specialism as "DE&I". That's a **person's professional self-description**, not house style. It needs their say-so, not a find-and-replace.

Both are judgement calls I'd rather surface than silently make.