### PR TITLE
content-guide: record that a canonical base exists in skylight-hub

### DIFF
--- a/pages/work/toolkits/content-guide/word_list.md
+++ b/pages/work/toolkits/content-guide/word_list.md
@@ -8,6 +8,16 @@ content_type: Toolkit
 toolkit_name: content-guide
 ---
 
+<!--
+  CANONICAL BASE: skylight-hub -> standards/content-guide.md
+  These pages are a hand-maintained SIBLING of that base, not a generated
+  render. Nothing syncs the two and no check catches drift, so a ruling
+  changed here must also be changed there (and vice versa). They diverged
+  for six weeks in 2026 over DEI / DE&I -> "fairness, belonging, and
+  accessibility" (hub #111, reconciled in #593).
+  HUB-A-025 tracks making this published form generated from the base.
+-->
+
 # Word list
 
 Below are rules for how we use common words and phrases. The bold term shows the accepted form (capitalization, hyphenation, punctuation), with accompanying text explaining usage.

--- a/pages/work/toolkits/content_guide.md
+++ b/pages/work/toolkits/content_guide.md
@@ -8,6 +8,16 @@ content_type: Toolkit
 toolkit_name: content-guide
 ---
 
+<!--
+  CANONICAL BASE: skylight-hub -> standards/content-guide.md
+  These pages are a hand-maintained SIBLING of that base, not a generated
+  render. Nothing syncs the two and no check catches drift, so a ruling
+  changed here must also be changed there (and vice versa). They diverged
+  for six weeks in 2026 over DEI / DE&I -> "fairness, belonging, and
+  accessibility" (hub #111, reconciled in #593).
+  HUB-A-025 tracks making this published form generated from the base.
+-->
+
 # About this guide
 
 This is our company content style guide. It helps us write clear, consistent, and accessible content across teams and channels. Please use it as a reference when you’re writing for Skylight. We hope that by using this guide, you learn how we talk to clients and partners, express ourselves online, and communicate about our work. This guide is here when you’re wondering whether to capitalize the word agile, for instance, or when you’re wondering how to create a friendly, informational tone.


### PR DESCRIPTION
Companion to #593, which fixed the *symptom*. This addresses the *cause*.

## Why they drifted

The published guide and `skylight-hub`'s `standards/content-guide.md` are two hand-maintained copies of the same guide — and **neither mentioned the other**. So when [hub #111](https://github.com/skylight-hq/skylight-hub/pull/111) retired the DEI umbrella on the canonical base, nobody knew a published copy existed to update. Six weeks later the site was telling writers "DE&I, not DEI" on one page and "fairness, belonging, and accessibility" on another.

Nothing was broken. The dependency was just **invisible**.

## What this adds

An HTML comment naming the base, stating that nothing syncs the two, and pointing at **HUB-A-025** (make this form generated from the base — the actual fix, deliberately deferred).

**It's a comment, not a gate.** It can't stop anyone. It just means the next editor knows the second copy is there. Given this drifted once, on one term, in six weeks, a note is proportionate — and a sync *can't work here anyway*: the base is one 3,729-line document, this is 17 Jekyll pages with their own front matter, permalinks and markup. Two presentations, not two copies.

## Two choices worth flagging

**HTML comment, not visible prose** — these pages are public. "This is a copy of an internal base in a private repo" is plumbing; it means nothing to a reader and shouldn't be on a public page.

**Two files, not all 17** — the landing page (the guide's front door) and `word_list.md` (the rulings register, and where the DE&I entry actually lived). Those are the two places an editor changing a ruling would realistically be. Seventeen copies of an anti-drift note would itself drift, which would be a poor joke.

The **hub-side note is the primary guard** — that's where rulings get authored, and it's the direction this actually failed in. This is the reverse-direction guard.