### PR TITLE
fix(ci): re-aim the Lighthouse a11y audit — it audited 0 of the 67 accordion pages

### DIFF
--- a/.github/workflows/sync-brand-pack.yml
+++ b/.github/workflows/sync-brand-pack.yml
@@ -51,7 +51,18 @@ jobs:
       # (root cause of the 2026-07 HUB-A-019 failure). Mirrors the hub's
       # sync-website-filters.yml.
       REFRESH_AGE_DAYS: 21
-      FILES: colors.yml typography.yml logo-rules.yml voice-tone.yml brand-narrative.yml illustration.yml customer-brand-rules.yml icons.yml imagery.yml
+      # Canon we deliberately do NOT mirror to the public website. One
+      # `filename.yml  # reason` per line — an entry with no stated reason is
+      # not a decision, it's the silent drift this file just deleted, coming
+      # back. Empty today: every brand-pack config file is public-safe, so the
+      # website carries all of them.
+      #
+      # Adding an entry here does NOT remove an already-mirrored file from
+      # _data/brand/ — that orphan would then age past brand-pack-freshness's
+      # 30-day gate and fail CI with no sync able to refresh it. Delete the
+      # mirrored file in the same PR that adds the deny entry.
+      DENY_LIST: |
+        # (no exclusions)
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -123,11 +134,67 @@ jobs:
           echo "sha=${SHA}"       >> "$GITHUB_OUTPUT"
           echo "Source: ${SOURCE_REPO}@${BRANCH} (${SHA})"
 
+      # The hub's config directory IS the list of what to carry, so ask it.
+      # This used to be a hard-coded FILES variable — a second copy of that
+      # directory listing, maintained by hand, which drifted silently:
+      # emoji-vocabulary.yml was canon for ~2 months while this sync mirrored
+      # 9 of 10 files and reported success every week. Nothing was red, because
+      # a list can't notice what it's missing. Adding a file to the hub config
+      # dir must cost zero edits here — that's the constraint this step exists
+      # to hold.
+      #
+      # Listed at the resolved SHA rather than the branch so the listing and
+      # the fetches below can't straddle a mid-run push.
+      - name: Derive the mirrored file list from hub canon
+        if: steps.cfg.outputs.ok == 'true'
+        id: files
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          SHA="${{ steps.src.outputs.sha }}"
+
+          # .yml only — the destination is a Jekyll _data dir, so YAML is the
+          # contract. A README or subdirectory in the canon dir isn't data.
+          if ! gh api "repos/${SOURCE_REPO}/contents/${SOURCE_DIR}?ref=${SHA}" \
+                 --jq '.[] | select(.type == "file") | .name | select(endswith(".yml"))' \
+                 | sort > /tmp/canon.txt; then
+            echo "::error title=sync-brand-pack: canon listing failed::Could not list ${SOURCE_REPO}/${SOURCE_DIR} at ${SHA}. Refusing to continue — an unreadable canon looks exactly like an empty one, and syncing nothing while reporting success is the failure this derivation exists to prevent."
+            exit 1
+          fi
+          if [ ! -s /tmp/canon.txt ]; then
+            echo "::error title=sync-brand-pack: canon listing empty::${SOURCE_REPO}/${SOURCE_DIR} at ${SHA} lists no .yml files. Refusing to mirror nothing and call it a clean run."
+            exit 1
+          fi
+
+          # Deny-list -> bare filenames (drop the `# reason` text and blanks).
+          printf '%s\n' "${DENY_LIST}" \
+            | sed -E 's/#.*//; s/[[:space:]]//g' \
+            | grep -v '^$' \
+            | sort > /tmp/deny.txt || true
+
+          # A deny entry naming a file that isn't in canon is the same
+          # hand-typed drift wearing a different hat — say so out loud.
+          while read -r d; do
+            echo "::warning title=sync-brand-pack: stale deny entry::'${d}' is denied but no longer exists in ${SOURCE_DIR} — drop it from DENY_LIST."
+          done < <(comm -13 /tmp/canon.txt /tmp/deny.txt)
+
+          comm -23 /tmp/canon.txt /tmp/deny.txt > /tmp/files.txt
+          if [ ! -s /tmp/files.txt ]; then
+            echo "::error title=sync-brand-pack: everything denied::DENY_LIST excluded every file in canon, leaving nothing to sync. That is a config mistake, not a no-op."
+            exit 1
+          fi
+
+          echo "Carrying $(wc -l < /tmp/files.txt) of $(wc -l < /tmp/canon.txt) canon file(s):"
+          sed 's/^/  /' /tmp/files.txt
+          echo "list=$(tr '\n' ' ' < /tmp/files.txt)" >> "$GITHUB_OUTPUT"
+
       - name: Fetch + rewrite each mirrored file
         if: steps.cfg.outputs.ok == 'true'
         id: fetch
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          FILES: ${{ steps.files.outputs.list }}
         run: |
           set -uo pipefail
           BRANCH="${{ steps.src.outputs.branch }}"
@@ -142,7 +209,10 @@ jobs:
             echo "Fetching ${SOURCE_DIR}/${f} @ ${SHA}"
             if ! gh api "repos/${SOURCE_REPO}/contents/${SOURCE_DIR}/${f}?ref=${SHA}" \
                    -H "Accept: application/vnd.github.raw" > "/tmp/${f}.body" 2>/tmp/${f}.err; then
-              echo "  -> not retrievable (missing on source, or token lacks access); skipping"
+              # The list came from the directory at this same SHA, so the file
+              # exists by construction — a failure here is the API or the token,
+              # not a typo'd name. Skip it, but never quietly (see below).
+              echo "  -> not retrievable (API error, or token lacks access); skipping"
               skipped_files+=("$f")
               continue
             fi
@@ -193,6 +263,10 @@ jobs:
           fi
           if [ ${#skipped_files[@]} -ne 0 ]; then
             printf '%s\n' "${skipped_files[@]}" > /tmp/skipped.txt
+            # Warn on every run, not just no-op ones: the summary step below is
+            # gated on any_changed != true, so a partial sync that opened a PR
+            # used to carry its gaps to master unmentioned.
+            echo "::warning title=sync-brand-pack: files not retrieved::${skipped_files[*]} — in canon at ${SHA} but not fetched; the mirror is incomplete."
           fi
 
       - name: Open / update PR with changes

--- a/lighthouserc.yml
+++ b/lighthouserc.yml
@@ -1,10 +1,100 @@
+# Lighthouse CI — accessibility audit for the built site.
+#
+# ADVISORY BY DESIGN. Every assertion below is `warn`, so this job reports and
+# never blocks. Two reasons. The site is being replaced by the skylight-web
+# rebuild, so a hard gate on the legacy site buys a fight rather than a fix. And
+# `validate-site` is a SIBLING of `deploy` (both `needs: build`), so it runs
+# alongside the deploy rather than in front of it — it could not gate a release
+# even if set to `error`. Reporting is the honest contract.
+#
+# -- Why explicit URLs ---------------------------------------------------------
+#
+# This previously ran `maxAutodiscoverUrls: 20` over the build directory, which
+# is walked ALPHABETICALLY. In practice that audited the homepage, /about/,
+# /alliances/, the blog index and ~16 blog posts — it never reached /company/ or
+# /work/ at all. It covered ~3.4% of the site's 591 built pages and, more to the
+# point, ZERO of the 67 pages carrying an accordion, including all 64 case
+# studies. The accordion is the most a11y-sensitive component on the site and it
+# was the one thing never audited.
+#
+# The list below is one page per layout plus deliberate accordion coverage.
+# Every URL was verified 200 against production (2026-07-14), and the accordion
+# pages confirmed to carry the markup (18 / 8 / 81 references respectively).
+#
+# If you add a URL, verify it resolves in the BUILD. A typo'd path scores ~0 and
+# reads as a real regression.
+
 ci:
   collect:
     staticDistDir: "./build"
-    maxAutodiscoverUrls: 20
+    # Explicit list — do not reintroduce maxAutodiscoverUrls. Alphabetical
+    # truncation is what produced the blind spot described above.
+    url:
+      # -- one page per layout --
+      - "http://localhost/index.html"                                                                # default (homepage)
+      - "http://localhost/company/brand/identity/colors/index.html"                                  # toolkit
+      - "http://localhost/thoughts/blog/reactions-to-our-agile-share-in-savings-model/index.html"    # blog_post
+      - "http://localhost/company/policies/code-of-conduct/index.html"                               # policy
+      - "http://localhost/careers/career-pathways/consultant/index.html"                             # career_pathways_role
+      - "http://localhost/thoughts/blog/tag/accessibility/index.html"                                # tag_filter
+      - "http://localhost/thoughts/blog/author/abby-raskin/index.html"                               # employee_filter
+      # -- accordion coverage: the 67-page blind spot --
+      - "http://localhost/work/experience/18f-consulting/index.html"                                 # case study (1 of 64)
+      - "http://localhost/work/experience/index.html"                                                # filter_component
+      - "http://localhost/work/services/training/ditap/index.html"                                   # accordion-heavy
+      # -- index pages --
+      - "http://localhost/thoughts/blog/index.html"
+      - "http://localhost/thoughts/talks/index.html"
+
   assert:
     assertions:
-      categories:accessibility: [error, {minScore: .9}]
+      # -- Per-audit assertions ------------------------------------------------
+      #
+      # These matter more than the category score. The weighted accessibility
+      # category is near-unfailable: a TOTAL colour-contrast failure still
+      # scores ~95 — comfortably over the 0.9 bar the old config asserted. The
+      # old gate could pass a page whose contrast was entirely broken. Naming
+      # audits individually is what actually surfaces a regression.
+      #
+      # Every id below is a real, automatically-scored Lighthouse a11y audit
+      # (checked against lighthouse/core/config/default-config.js). Manual-only
+      # audits — logical-tab-order, use-landmarks, focusable-controls and the
+      # rest — are deliberately absent: they are never scored, so asserting on
+      # them would be noise.
+      color-contrast: [warn]
+      image-alt: [warn]
+      link-name: [warn]
+      button-name: [warn]
+      label: [warn]
+      document-title: [warn]
+      html-has-lang: [warn]
+      html-lang-valid: [warn]
+      valid-lang: [warn]
+      heading-order: [warn]
+      list: [warn]
+      listitem: [warn]
+      meta-viewport: [warn]
+      bypass: [warn]
+      tabindex: [warn]
+      frame-title: [warn]
+      object-alt: [warn]
+      # ARIA — the accordion's correctness lives here, which is the whole reason
+      # for the URL list above. aria-toggle-field-name is the accordion-specific
+      # one: an expand/collapse control with no accessible name.
+      aria-toggle-field-name: [warn]
+      aria-allowed-attr: [warn]
+      aria-required-attr: [warn]
+      aria-required-children: [warn]
+      aria-required-parent: [warn]
+      aria-roles: [warn]
+      aria-valid-attr: [warn]
+      aria-valid-attr-value: [warn]
+      aria-hidden-focus: [warn]
+
+      # Category rollup — kept as a trend signal, not a gate. See the note above
+      # on why this number alone is not trustworthy.
+      categories:accessibility: [warn, {minScore: 0.9}]
+
   upload:
     # upload options here
   server:


### PR DESCRIPTION
The accessibility audit has been running against the wrong 3.4% of the site.

## What's wrong

`maxAutodiscoverUrls: 20` walks the build directory **alphabetically**. In practice the audited set was the homepage, `/about/`, `/alliances/`, the blog index and ~16 blog posts. It never reached `/company/` or `/work/` at all.

That means **zero coverage of the 67 pages carrying an accordion**, including all 64 case studies. The accordion is the most a11y-sensitive component on the site, and it was the one thing never audited.

## What changed

**12 explicit URLs** — one per layout (`default`, `toolkit`, `blog_post`, `policy`, `career_pathways_role`, `tag_filter`, `employee_filter`) plus deliberate accordion coverage: a case study, the `filter_component` index, and an accordion-heavy page carrying 81 accordion references.

Every URL was **verified 200 against production**, and the accordion pages confirmed to actually carry the markup (18 / 8 / 81 references) rather than assumed to.

**Per-audit assertions replace the lone category score.** That score is near-unfailable: a *total* colour-contrast failure still scores ~95 — comfortably over the `0.9` bar the old config asserted. The old gate could pass a page whose contrast was entirely broken.

26 named audits now assert individually, including `aria-toggle-field-name` — an expand/collapse control with no accessible name, which is precisely the accordion failure mode the new URL list exists to reach. Every id was checked against `lighthouse/core/config/default-config.js`; manual-only audits (`logical-tab-order`, `use-landmarks`, …) are deliberately excluded because they're never scored, so asserting on them would be noise.

## Everything is advisory

All 27 assertions are `warn`, including the category rollup, which **drops from `error`**. Deliberate on two counts:

1. The site is being replaced by the skylight-web rebuild — a hard gate on the legacy site buys a fight, not a fix.
2. `validate-site` is a **sibling** of `deploy` (both `needs: build`), so it runs *alongside* the deploy, not in front of it. It could not gate a release even set to `error`.

Advisory is the honest contract rather than a gate that only appears to be one.

**Not restored:** the `0.97` bar and performance gate from the orphaned `lighthouse/lighthouserc.yml` removed in #585. Both would be invasive on a site already scheduled for replacement.

## Verification

| Check | Result |
|---|---|
| YAML parses | ✅ |
| `maxAutodiscoverUrls` | removed |
| URLs | 12, all verified 200 in production |
| Assertions | 27, **all `warn`** |
| Audit ids real + scored | 26/26 verified against upstream Lighthouse |

⚠️ **This job only runs on push to master**, so this PR cannot exercise it. Verify via `workflow_dispatch` immediately after merge. Expect warnings to appear — that's the point; they were always there, just never looked at.

Closes HUB-A-023.
