### PR TITLE
fix(refs): repoint four moved skylight-hub cross-repo links

### DIFF
--- a/_data/_taxonomy_migration_notes.md
+++ b/_data/_taxonomy_migration_notes.md
@@ -6,7 +6,7 @@ This file accompanies the new `_data/technologies.yml` and `_data/practices.yml`
 2. **General mapping rules** that apply to the full 64-case-study migration.
 3. **Known ambiguities** that need editorial review.
 
-The full per-case-study migration is tracked in [`skylight-hub/migrations/case-study-taxonomy-rationalization.md`](https://github.com/skylight-hq/skylight-hub/blob/main/migrations/case-study-taxonomy-rationalization.md).
+The full per-case-study migration is tracked in [`skylight-hub/migrations/archive/2026-05-27-case-study-taxonomy-rationalization.md`](https://github.com/skylight-hq/skylight-hub/blob/main/migrations/archive/2026-05-27-case-study-taxonomy-rationalization.md).
 
 ## General rules
 
@@ -314,6 +314,6 @@ Unknown values become blocking linter findings, forcing a deliberate canonical-l
 
 ## Cross-references
 
-- Strategic proposal: [`skylight-hub-proposals-resolve/proposals/active/website-filter-rationalization.md`](https://github.com/skylight-hq/skylight-hub/blob/main/skylight-hub-proposals-resolve/proposals/active/website-filter-rationalization.md)
-- Operational migration plan: [`skylight-hub/migrations/case-study-taxonomy-rationalization.md`](https://github.com/skylight-hq/skylight-hub/blob/main/migrations/case-study-taxonomy-rationalization.md)
-- Filters pack plan: [`skylight-hub/migrations/website-filters-pack.md`](https://github.com/skylight-hq/skylight-hub/blob/main/migrations/website-filters-pack.md)
+- Strategic proposal: [`skylight-hub/plans/archived/adopted/0005-website-filter-rationalization.md`](https://github.com/skylight-hq/skylight-hub/blob/main/plans/archived/adopted/0005-website-filter-rationalization.md)
+- Operational migration plan: [`skylight-hub/migrations/archive/2026-05-27-case-study-taxonomy-rationalization.md`](https://github.com/skylight-hq/skylight-hub/blob/main/migrations/archive/2026-05-27-case-study-taxonomy-rationalization.md)
+- Filters pack plan: [`skylight-hub/migrations/archive/2026-05-22-website-filters-pack.md`](https://github.com/skylight-hq/skylight-hub/blob/main/migrations/archive/2026-05-22-website-filters-pack.md)

--- a/_data/practices.yml
+++ b/_data/practices.yml
@@ -543,4 +543,4 @@ practices:
 #   - "Live redevelopment" — captured under legacy-modernization
 #   - Several over-specialized API entries — consolidated under api-design
 #
-# Per-case-study migration tracked in skylight-hub/migrations/case-study-taxonomy-rationalization.md.
+# Per-case-study migration tracked in skylight-hub/migrations/archive/2026-05-27-case-study-taxonomy-rationalization.md.

--- a/_data/technologies.yml
+++ b/_data/technologies.yml
@@ -776,4 +776,4 @@ technologies:
 #   - "JavaScript / React / TypeScript" and 6 other React composites (split)
 #   - "HTML / CSS / Sass / SVG" and other style composites (split)
 #
-# Per-case-study migration tracked in skylight-hub/migrations/case-study-taxonomy-rationalization.md.
+# Per-case-study migration tracked in skylight-hub/migrations/archive/2026-05-27-case-study-taxonomy-rationalization.md.


### PR DESCRIPTION
## What

Four links in `_data/_taxonomy_migration_notes.md` point at `skylight-hub` paths that have since moved. All four 404 today. This repoints them at their current locations. No other changes.

## Why each one was wrong

| Old target | Why it broke | New target |
|---|---|---|
| `migrations/case-study-taxonomy-rationalization.md` (2 occurrences — L9, L318) | The hub archives completed migration plans into `migrations/archive/` and date-prefixes them on completion. This one completed 2026-05-27. | `migrations/archive/2026-05-27-case-study-taxonomy-rationalization.md` |
| `migrations/website-filters-pack.md` (L319) | Same archival convention; completed 2026-05-22. | `migrations/archive/2026-05-22-website-filters-pack.md` |
| `skylight-hub-proposals-resolve/proposals/active/website-filter-rationalization.md` (L317) | Two separate breakages compounded. The `skylight-hub-proposals-resolve/` directory prefix no longer exists in the hub at all, **and** the proposal was subsequently graduated into the hub's numbered ADR set — which moved it under `plans/archived/adopted/` and gave the filename an `0005-` sequence prefix. | `plans/archived/adopted/0005-website-filter-rationalization.md` |

The common thread: these are all normal hub lifecycle transitions (a migration completing, a proposal being adopted). Nothing was deleted — the documents are all still there, just at their post-lifecycle addresses. A cross-repo link has no way to follow that on its own, which is exactly why they went stale silently.

## Label convention followed

Three of the four link labels already used the `skylight-hub/<path>` form; only the proposal link (L317) used a bare in-hub path with no repo prefix. I followed the dominant convention and normalized that one to `skylight-hub/plans/archived/adopted/0005-website-filter-rationalization.md`, so all three bullets in the Cross-references list now read consistently. Labels were updated to match their new hrefs throughout — no label still quotes a dead path.

## Verification

Each new path was confirmed present in the live hub tree at `main`:

```
gh api "repos/skylight-hq/skylight-hub/git/trees/main?recursive=1" --jq '.tree[].path' | grep -x '<path>'
```

All three resolve (1 hit each). The check was run with a positive control (`README.md`, 1 hit — proves the tree fetch actually returned data) and a negative control (the old paths, 0 hits — confirms they are genuinely gone rather than the grep silently failing). A repo-wide grep confirms no stale form of any of these three paths survives anywhere in the tree.

## Deliberately out of scope

- **The hub's reference-checker script is not synced here.** This is a Jekyll site with a different CI shape; importing the checker is a separate decision.
- **`skylight-hub-proposals-resolve` also appears in `scripts/scaffold_asset_manifest.rb:72` and `standards/asset-manifest-schema.yml:58`.** Those are *not* path references — it is a federation-member repo slug in a `REPO_ENUM` / schema `enum`. Given the directory is gone from the hub, that enum entry may well be stale too, but validating whether that repo still exists as a federation member is a different question from fixing a broken link, so I left it alone. Flagging it here rather than silently touching it.
