### PR TITLE
fix(filters): match experience-page filter tags case-insensitively

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -176,7 +176,7 @@ $(function() {
     var usedTags = $.unique(
       Object.values(
         posts.map(function() {
-          return $(this).attr("data-tags").split(", ");
+          return $(this).attr("data-tags").toLowerCase().split(", ");
         })
       )
     );
@@ -272,7 +272,7 @@ $(function() {
     var filterPosts = function filterPosts() {
       if (filters.length) {
         posts.each(function() {
-          var tags = $(this).attr("data-tags").split(", ");
+          var tags = $(this).attr("data-tags").toLowerCase().split(", ");
           if (
             tags &&
             tags.filter(function(tag) {
@@ -295,7 +295,7 @@ $(function() {
       var usedTags = $.unique(
         Object.values(
           dataSource.map(function() {
-            return $(this).attr("data-tags").split(", ");
+            return $(this).attr("data-tags").toLowerCase().split(", ");
           })
         )
       );


### PR DESCRIPTION
## Summary

The May 2026 case-study taxonomy rationalization (Phase 3 cluster PRs) re-cased every project's `tags:` front matter to canonical capitalization (e.g. `"service delivery"` → `"Service delivery"`). The experience-page filter JS lowercases each filter label but compared it against the raw `data-tags` values — case-sensitively. After the migration no label could match any tag, so every one of the 36 filter items failed the used-tags check, received `filter-disabled` (`pointer-events: none`), and the whole "Filter by category" panel on /work/experience/ became inert.

## Fix

Lowercase `data-tags` at the three places it's read in `js/script.js`, making tag matching casing-agnostic regardless of how tags are displayed. Fixing the JS (rather than reverting 64 case-study files) keeps the Title Case tags, which are the intended canonical form, and makes the filter component safe to reuse on other pages with any tag casing.

## Verification

Ran the site locally with Jekyll and exercised the real page:
- All 36 filter items initialize as `filter-enabled` (previously all 36 were `filter-disabled`)
- Clicking "Early childhood" bolds the item, adds the removable tag badge, and narrows the grid to the 5 early-childhood case studies (every visible card carries the tag)
- Stacking "Software delivery" narrows further to 3 (AND logic intact)
- Incompatible filters (e.g. "Defense") correctly gray out while a filter is active and re-enable on clear
- Removing badges restores the full paginated grid; localStorage filter persistence still works
- No console errors