### PR TITLE
fix(ci): the two brand-pack alerts now notify someone, and close themselves

### DIFF
--- a/.github/workflows/brand-pack-freshness.yml
+++ b/.github/workflows/brand-pack-freshness.yml
@@ -80,8 +80,17 @@ jobs:
 
       # PR/push failures are visible on the PR/commit; schedule failures
       # previously vanished — this check was red for 3+ days unseen in 2026-07.
-      - name: Alert on failure
-        if: ${{ failure() && github.event_name != 'pull_request' }}
+      #
+      # ASSIGNED and SELF-CLOSING (federation-ci-operability.md W1/W2, ported here as W5b). An
+      # unassigned labelled issue sends no notification, so the issue this job raised could sit unread
+      # for exactly the reason the job was added. And without the close step below, an OPEN ops-alert
+      # meant "was red at some point", not "is red now" — the body used to ask a human to close it,
+      # which is the append-only list of indistinguishable stale rows W2 exists to prevent.
+      #
+      # Both halves carry the `!= 'pull_request'` guard: PR results are visible on the PR itself, and
+      # a green PR run must not close an alert raised by a red run on master.
+      - name: Close the ops-alert issue when the job is green again
+        if: ${{ success() && github.event_name != 'pull_request' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -89,7 +98,21 @@ jobs:
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           existing=$(gh issue list --repo "${{ github.repository }}" --label ops-alert --state open --search "\"$title\" in:title" --json number --jq '.[0].number')
           if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            gh issue close "$existing" --repo "${{ github.repository }}" --comment "Green again: $run_url"
+          fi
+
+      - name: Alert on failure
+        if: ${{ failure() && github.event_name != 'pull_request' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ASSIGNEE: ${{ vars.OPS_ALERT_ASSIGNEE || 'cscairns' }}
+        run: |
+          title="Scheduled run failed: brand-pack-freshness"
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          existing=$(gh issue list --repo "${{ github.repository }}" --label ops-alert --state open --search "\"$title\" in:title" --json number --jq '.[0].number')
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
             gh issue comment "$existing" --repo "${{ github.repository }}" --body "Failed again: $run_url"
           else
-            gh issue create --repo "${{ github.repository }}" --label ops-alert --title "$title" --body "The scheduled run failed: $run_url — likely the vendored brand-pack aged past the 30-day gate; dispatch sync-brand-pack and merge its PR. This issue collects repeat failures; close it when the job is green again."
+            gh issue create --repo "${{ github.repository }}" --label ops-alert --assignee "$ASSIGNEE" --title "$title" --body "The scheduled run failed: $run_url — likely the vendored brand-pack aged past the 30-day gate; dispatch sync-brand-pack and merge its PR. This issue collects repeat failures and closes itself when the job is green again." \
+              || gh issue create --repo "${{ github.repository }}" --label ops-alert --title "$title" --body "The scheduled run failed: $run_url — likely the vendored brand-pack aged past the 30-day gate; dispatch sync-brand-pack and merge its PR. This issue collects repeat failures and closes itself when the job is green again."
           fi

--- a/.github/workflows/sync-brand-pack.yml
+++ b/.github/workflows/sync-brand-pack.yml
@@ -302,8 +302,16 @@ jobs:
             cat /tmp/skipped.txt
           fi
 
-      - name: Alert on failure
-        if: ${{ failure() }}
+      # ASSIGNED and SELF-CLOSING (federation-ci-operability.md W1/W2, ported here as W5b). An
+      # unassigned labelled issue sends no notification; and without the close step, an OPEN
+      # ops-alert meant "was red at some point", not "is red now" — the body used to ask a human to
+      # close it, which is the append-only list of stale rows W2 exists to prevent.
+      #
+      # NO `!= 'pull_request'` guard, unlike brand-pack-freshness.yml: this workflow declares only
+      # `schedule` and `workflow_dispatch`, so a PR run cannot occur and a guard against one would
+      # imply a PR path exists.
+      - name: Close the ops-alert issue when the job is green again
+        if: ${{ success() }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -311,7 +319,21 @@ jobs:
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           existing=$(gh issue list --repo "${{ github.repository }}" --label ops-alert --state open --search "\"$title\" in:title" --json number --jq '.[0].number')
           if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            gh issue close "$existing" --repo "${{ github.repository }}" --comment "Green again: $run_url"
+          fi
+
+      - name: Alert on failure
+        if: ${{ failure() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ASSIGNEE: ${{ vars.OPS_ALERT_ASSIGNEE || 'cscairns' }}
+        run: |
+          title="Scheduled run failed: sync-brand-pack"
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          existing=$(gh issue list --repo "${{ github.repository }}" --label ops-alert --state open --search "\"$title\" in:title" --json number --jq '.[0].number')
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
             gh issue comment "$existing" --repo "${{ github.repository }}" --body "Failed again: $run_url"
           else
-            gh issue create --repo "${{ github.repository }}" --label ops-alert --title "$title" --body "The scheduled run failed: $run_url — investigate and re-run (workflow_dispatch). This issue collects repeat failures; close it when the job is green again."
+            gh issue create --repo "${{ github.repository }}" --label ops-alert --assignee "$ASSIGNEE" --title "$title" --body "The scheduled run failed: $run_url — investigate and re-run (workflow_dispatch). This issue collects repeat failures and closes itself when the job is green again." \
+              || gh issue create --repo "${{ github.repository }}" --label ops-alert --title "$title" --body "The scheduled run failed: $run_url — investigate and re-run (workflow_dispatch). This issue collects repeat failures and closes itself when the job is green again."
           fi


### PR DESCRIPTION
Closes the last instance of **W5b** in the hub's `federation-ci-operability.md`.

`brand-pack-freshness.yml` and `sync-brand-pack.yml` raised an ops-alert issue on failure but left out both halves of what makes one useful.

**No `--assignee`.** GitHub sends no notification for an unassigned labelled issue. So the issue this job raises could sit unread for precisely the reason the job exists — `brand-pack-freshness` was itself added after this check sat red for 3+ days unseen in 2026-07.

**No auto-close.** Both bodies asked a human to *"close it when the job is green again"*, so an OPEN ops-alert meant "was red at some point", not "is red now" — the append-only list of indistinguishable stale rows W2 exists to prevent. The body wording is corrected in the same change, since leaving it would describe a job the workflow now does itself.

These were the **last two workflows in the federation** missing the W1/W2 pair; the other 25 scheduled workflows across the 10 repos already carry both.

## One deliberate asymmetry

The guard differs between the two files, and each explains itself in place:

- **`brand-pack-freshness.yml`** runs on `pull_request`, `push` and `schedule`, so both halves keep `!= 'pull_request'`. PR results are visible on the PR itself, and a green PR run must not close an alert raised by a red run on `master`.
- **`sync-brand-pack.yml`** declares only `schedule` and `workflow_dispatch`, so it carries no guard — one there would imply a PR path exists.

## Verification

- Both files parse; each has the close/alert pair with the expected `if:` conditions, and `ASSIGNEE` on the alert half only.
- **Both `title=` strings match byte-for-byte within each file** — without that the close step could never find the issue the alert step opened, which is the failure mode that makes "open ops-alert" stop meaning "currently red".
- No `"close it when the job is green"` wording remains.
- The `ops-alert` label already exists in this repo, and both workflows already had `issues: write`.

## Note on the W5b entry itself

The hub's plan doc describes W5b as 6 blocks missing the pair, across skylight.digital, skylight-people-ops, skylight-marcom and skylight-web. That is now stale: people-ops, marcom and web have all since been fixed, and only these two remained. I'm correcting that entry in a companion hub PR rather than here.
